### PR TITLE
chore: 允许 macOS app 客户端网络权限

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,8 +6,6 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS 应用程序的沙盒环境下需要配置应用程序的网络权限，原先的 Xcode 配置好像只允许了debug的网络连接，得把release的也允许一下~
（另：我把debug的server权限去掉了，看上去不需要用到server网络权限的样子只要client就好了……

不然编译后运行会无法联网：
<img width="718" alt="image" src="https://github.com/Celechron/Celechron/assets/23137268/b14247c6-a961-4e7c-b8f3-b9f8b8c2451f">

btw，github release里你们也可以把macOS版本打包的dmg丢上去，很方便的）
（or maybe你们其实没在macOS上运行过_(:з」∠)_ 
_不过iOS版运行起来相当不错，~~比某潮v4好多了~~_

bbtw，记得改macOS版本的AppIcon，你们应该是忘记改了，还是flutter图标（