### PR TITLE
feat: 支持研究生课表/考试/成绩

### DIFF
--- a/lib/model/course.dart
+++ b/lib/model/course.dart
@@ -24,7 +24,16 @@ class Course {
     exams.addAll(examDto.exams);
   }
 
+  // used for grs
   Course.fromSession(Session session) {
+    id = session.id;
+    name = session.name;
+    confirmed = session.confirmed;
+    teacher = session.teacher;
+    sessions.add(session);
+  }
+  // used for zdbk
+  Course.fromSessionWithoutID(Session session) {
     name = session.name;
     confirmed = session.confirmed;
     teacher = session.teacher;
@@ -34,6 +43,13 @@ class Course {
   Course.fromGrade(Grade this.grade)
       : id = grade.id,
         name = grade.name,
+        confirmed = true,
+        credit = grade.credit;
+
+  // used for grs
+  // grs的获取课表接口和获取成绩接口拿到的id不同，一切id以课表接口为准
+  Course.fromGradeWithoutID(Grade this.grade)
+      : name = grade.name,
         confirmed = true,
         credit = grade.credit;
 
@@ -58,7 +74,9 @@ class Course {
     exams.addAll(examDto.exams);
     // 如果调用了这个函数，则表明该Course对象可能是基于Session创建的。因此，id可能为null，必须补全。
     id ??= examDto.id;
-    for (var e in sessions) { e.id = id; }
+    for (var e in sessions) {
+      e.id = id;
+    }
   }
 
   bool completeSession(Session session) {
@@ -114,8 +132,14 @@ class Course {
         name = json['name'] as String,
         confirmed = json['confirmed'] as bool,
         credit = json['credit'] as double,
-        grade = json['grade'] == null ? null : Grade.fromJson(json['grade'] as Map<String, dynamic>),
+        grade = json['grade'] == null
+            ? null
+            : Grade.fromJson(json['grade'] as Map<String, dynamic>),
         teacher = json['teacher'] as String?,
-        sessions = (json['sessions'] as List<dynamic>).map((e) => Session.fromJson(e as Map<String, dynamic>)).toList(),
-        exams = (json['exams'] as List<dynamic>).map((e) => Exam.fromJson(e as Map<String, dynamic>)).toList();
+        sessions = (json['sessions'] as List<dynamic>)
+            .map((e) => Session.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        exams = (json['exams'] as List<dynamic>)
+            .map((e) => Exam.fromJson(e as Map<String, dynamic>))
+            .toList();
 }

--- a/lib/model/exam.dart
+++ b/lib/model/exam.dart
@@ -10,7 +10,14 @@ class Exam {
   String? location;
   String? seat;
 
-  Exam._fromAppService(this.id, this.name, Map<String, dynamic> json, this.type) {
+  Exam.empty()
+      : id = "",
+        name = "",
+        type = ExamType.finalExam,
+        time = [];
+
+  Exam._fromAppService(
+      this.id, this.name, Map<String, dynamic> json, this.type) {
     switch (type) {
       case ExamType.midterm:
         time = TimeHelper.parseExamDateTime(json['qzkssj']);

--- a/lib/model/exams_dto.dart
+++ b/lib/model/exams_dto.dart
@@ -6,29 +6,38 @@ class ExamDto {
   double credit;
   late List<Exam> exams;
 
-  String get semesterId => id.substring(1, 12);
+  // only used for ugrs
+  String get semesterId => id.length > 12 ? id.substring(1, 12) : "研究生请勿使用此函数";
+
+  ExamDto.empty()
+      : id = "",
+        name = "",
+        credit = 0,
+        exams = [];
 
   // 第一个元素是开始时间，第二个元素是结束时间
-  ExamDto(Map<String, dynamic> json) :
-    id = json['xkkh'] as String,
-    name = (json['kcmc'] as String).replaceAll('(','（').replaceAll(')', '）'),
-    credit = double.parse(json['xkxf'] as String) {
+  ExamDto(Map<String, dynamic> json)
+      : id = json['xkkh'] as String,
+        name =
+            (json['kcmc'] as String).replaceAll('(', '（').replaceAll(')', '）'),
+        credit = double.parse(json['xkxf'] as String) {
     exams = Exam.parseExams(json, id, name);
   }
 
-  ExamDto.fromZdbk(Map<String, dynamic> json) :
-    id = json['xkkh'] as String,
-    name = (json['kcmc'] as String).replaceAll('(','（').replaceAll(')', '）'),
-    credit = double.parse(json['xf'] as String) {
+  ExamDto.fromZdbk(Map<String, dynamic> json)
+      : id = json['xkkh'] as String,
+        name =
+            (json['kcmc'] as String).replaceAll('(', '（').replaceAll(')', '）'),
+        credit = double.parse(json['xf'] as String) {
     exams = Exam.parseExamsFromZdbk(json, id, name);
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'name': name,
-    'credit': credit,
-    'exams': exams,
-  };
+        'id': id,
+        'name': name,
+        'credit': credit,
+        'exams': exams,
+      };
 
   ExamDto.fromJson(Map<String, dynamic> json)
       : id = json['id'],

--- a/lib/model/grade.dart
+++ b/lib/model/grade.dart
@@ -17,7 +17,8 @@ class Grade {
   // 获得的学分（挂科、不计学分的不计）
   double get earnedCredit => (creditIncluded && fivePoint != 0) ? credit : 0.0;
 
-  String get semesterId => id.substring(1, 12);
+  // only used for ugrs
+  String get semesterId => id.length > 12 ? id.substring(1, 12) : "研究生请勿使用此函数";
 
   static final Map<double, double> _toFourPoint = {
     5.0: 4.3,
@@ -50,6 +51,13 @@ class Grade {
     "缓考": 0,
     "待录": 0,
   };
+
+  Grade.empty()
+      : id = "",
+        name = "",
+        credit = 0.0,
+        original = "",
+        fivePoint = 0.0;
 
   // 从所有成绩查询处爬取，因此不含主修标记
   Grade(Map<String, dynamic> json)

--- a/lib/model/semester.dart
+++ b/lib/model/semester.dart
@@ -31,74 +31,9 @@ class Semester {
     [],
     [],
     [],
-    []
-  ];
-
-  final List<List<Duration>> _sessionToTimeGrs = [
-    [
-      const Duration(hours: 0, minutes: 0),
-      const Duration(hours: 0, minutes: 0)
-    ],
-    [
-      const Duration(hours: 8, minutes: 0),
-      const Duration(hours: 8, minutes: 45)
-    ],
-    [
-      const Duration(hours: 8, minutes: 50),
-      const Duration(hours: 9, minutes: 35)
-    ],
-    [
-      const Duration(hours: 10, minutes: 0),
-      const Duration(hours: 10, minutes: 45)
-    ],
-    [
-      const Duration(hours: 10, minutes: 50),
-      const Duration(hours: 11, minutes: 35)
-    ],
-    [
-      const Duration(hours: 11, minutes: 40),
-      const Duration(hours: 12, minutes: 25)
-    ],
-    [
-      const Duration(hours: 13, minutes: 25),
-      const Duration(hours: 14, minutes: 10)
-    ],
-    [
-      const Duration(hours: 12, minutes: 40),
-      const Duration(hours: 13, minutes: 20)
-    ],
-    [
-      const Duration(hours: 13, minutes: 30),
-      const Duration(hours: 14, minutes: 10)
-    ],
-    [
-      const Duration(hours: 14, minutes: 15),
-      const Duration(hours: 15, minutes: 00)
-    ],
-    [
-      const Duration(hours: 15, minutes: 05),
-      const Duration(hours: 15, minutes: 50)
-    ],
-    [
-      const Duration(hours: 16, minutes: 15),
-      const Duration(hours: 17, minutes: 00)
-    ],
-    [
-      const Duration(hours: 17, minutes: 05),
-      const Duration(hours: 17, minutes: 50)
-    ],
-    [
-      const Duration(hours: 18, minutes: 50),
-      const Duration(hours: 19, minutes: 35)
-    ],
-    [
-      const Duration(hours: 19, minutes: 40),
-      const Duration(hours: 20, minutes: 25)
-    ],
-    [
-      const Duration(hours: 20, minutes: 30),
-      const Duration(hours: 21, minutes: 15)
-    ]
+    [],
+    [],
+    [], //14
   ];
 
   // 星期几 => 日期，_dayOfWeekToDays.first为上半学期，_dayOfWeekToDays.last为下半学期
@@ -215,12 +150,8 @@ class Semester {
                 description: "教师: ${session.teacher}",
                 location: session.location ?? "未知",
                 summary: session.name,
-                startTime: day.add(session.isGrsClass
-                    ? _sessionToTimeGrs[session.time.first].first
-                    : _sessionToTime[session.time.first].first),
-                endTime: day.add(session.isGrsClass
-                    ? _sessionToTimeGrs[session.time.last].last
-                    : _sessionToTime[session.time.last].last));
+                startTime: day.add(_sessionToTime[session.time.first].first),
+                endTime: day.add(_sessionToTime[session.time.last].last));
             periods.add(period);
           }
         }
@@ -233,12 +164,8 @@ class Semester {
                 description: "教师: ${session.teacher}",
                 location: session.location ?? "未知",
                 summary: session.name,
-                startTime: day.add(session.isGrsClass
-                    ? _sessionToTimeGrs[session.time.first].first
-                    : _sessionToTime[session.time.first].first),
-                endTime: day.add(session.isGrsClass
-                    ? _sessionToTimeGrs[session.time.last].last
-                    : _sessionToTime[session.time.last].last));
+                startTime: day.add(_sessionToTime[session.time.first].first),
+                endTime: day.add(_sessionToTime[session.time.last].last));
             periods.add(period);
           }
         }
@@ -253,12 +180,8 @@ class Semester {
               description: "教师: ${session.teacher}",
               location: session.location ?? "未知",
               summary: session.name,
-              startTime: day.add(session.isGrsClass
-                  ? _sessionToTimeGrs[session.time.first].first
-                  : _sessionToTime[session.time.first].first),
-              endTime: day.add(session.isGrsClass
-                  ? _sessionToTimeGrs[session.time.last].last
-                  : _sessionToTime[session.time.last].last),
+              startTime: day.add(_sessionToTime[session.time.first].first),
+              endTime: day.add(_sessionToTime[session.time.last].last),
             );
             periods.add(period);
           }
@@ -272,12 +195,8 @@ class Semester {
               description: "教师: ${session.teacher}",
               location: session.location ?? "未知",
               summary: session.name,
-              startTime: day.add(session.isGrsClass
-                  ? _sessionToTimeGrs[session.time.first].first
-                  : _sessionToTime[session.time.first].first),
-              endTime: day.add(session.isGrsClass
-                  ? _sessionToTimeGrs[session.time.last].last
-                  : _sessionToTime[session.time.last].last),
+              startTime: day.add(_sessionToTime[session.time.first].first),
+              endTime: day.add(_sessionToTime[session.time.last].last),
             );
             periods.add(period);
           }
@@ -319,7 +238,7 @@ class Semester {
     }
   }
 
-  void addSession(Session session, String semesterId) {
+  void addSession(Session session, String semesterId, [bool isGrs = false]) {
     // 由于ZDBK不给课号，Session的id初始值为null，不能直接拿来用！
     var key = '$semesterId${session.name}';
     if (_courses.containsKey(key)) {
@@ -329,14 +248,23 @@ class Semester {
       }
     } else {
       _sessions.add(session);
-      _courses.addEntries([MapEntry(key, Course.fromSession(session))]);
+      if (isGrs) {
+        _courses.addEntries([MapEntry(key, Course.fromSession(session))]);
+      } else {
+        _courses
+            .addEntries([MapEntry(key, Course.fromSessionWithoutID(session))]);
+      }
     }
   }
 
   void addExam(ExamDto examDto) {
+    addExamWithSemester(examDto, examDto.semesterId);
+  }
+
+  void addExamWithSemester(ExamDto examDto, String semesterId) {
     // 有的课没有考试，但是能查到考试信息，其考试时间为null。
     _exams.addAll(examDto.exams);
-    var key = '${examDto.semesterId}${examDto.name}';
+    var key = '$semesterId${examDto.name}';
     if (_courses.containsKey(key)) {
       _courses[key]!.completeExam(examDto);
     } else {
@@ -345,12 +273,21 @@ class Semester {
   }
 
   void addGrade(Grade grade) {
+    addGradeWithSemester(grade, grade.semesterId);
+  }
+
+  void addGradeWithSemester(Grade grade, String semesterId,
+      [bool isGrs = false]) {
     _grades.add(grade);
-    var key = '${grade.semesterId}${grade.name}';
+    var key = '$semesterId${grade.name}';
     if (_courses.containsKey(key)) {
       _courses[key]!.completeGrade(grade);
     } else {
-      _courses.addEntries([MapEntry(key, Course.fromGrade(grade))]);
+      if (isGrs) {
+        _courses.addEntries([MapEntry(key, Course.fromGradeWithoutID(grade))]);
+      } else {
+        _courses.addEntries([MapEntry(key, Course.fromGrade(grade))]);
+      }
     }
   }
 

--- a/lib/model/session.dart
+++ b/lib/model/session.dart
@@ -6,7 +6,6 @@ class Session {
   bool confirmed;
   int dayOfWeek;
   late List<int> time;
-  bool? grsClass;
 
   // firstHalf : 秋/春 需要上课
   // secondHalf: 夏/冬 需要上课
@@ -25,10 +24,10 @@ class Session {
   static const String dayMap = '零一二三四五六日';
 
   Session.empty()
-    : confirmed = true,
-      oddWeek = false,
-      evenWeek = false,
-      dayOfWeek = 1;
+      : confirmed = true,
+        oddWeek = false,
+        evenWeek = false,
+        dayOfWeek = 1;
 
   Session(Map<String, dynamic> json)
       : id = RegExp(r'(.*?-){5}\d+(?=.*\d{10})')
@@ -56,12 +55,18 @@ class Session {
         evenWeek = (json['dsz'] as String) != '0' {
     //名称、教师、地点
     if (json.containsKey('kcb')) {
-      var nameTeacherPosition = RegExp(r'(.*?)<br>(.*?)<br>(.*?)<br>(.*?)zwf').firstMatch(json['kcb'] as String);
-      if(nameTeacherPosition != null) {
+      var nameTeacherPosition = RegExp(r'(.*?)<br>(.*?)<br>(.*?)<br>(.*?)zwf')
+          .firstMatch(json['kcb'] as String);
+      if (nameTeacherPosition != null) {
         // ZDBK上，课程名称中的括号有时会变成英文括号，此处统一改成中文括号
-        name = nameTeacherPosition.group(1)!.replaceAll('(', '（').replaceAll(')', '）');
+        name = nameTeacherPosition
+            .group(1)!
+            .replaceAll('(', '（')
+            .replaceAll(')', '）');
         teacher = nameTeacherPosition.group(3)!;
-        location = nameTeacherPosition.group(4) == '' ? null : nameTeacherPosition.group(4);
+        location = nameTeacherPosition.group(4) == ''
+            ? null
+            : nameTeacherPosition.group(4);
       }
     }
     // 短学期 or 长学期
@@ -74,24 +79,23 @@ class Session {
     if (json.containsKey('djj') && json.containsKey('skcd')) {
       var initial = int.parse(json['djj'] as String);
       var duration = int.parse(json['skcd'] as String);
-      time = List<int>.generate(duration, (index) => initial+index);
+      time = List<int>.generate(duration, (index) => initial + index);
     }
   }
 
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'name': name,
-    'teacher': teacher,
-    'confirmed': confirmed,
-    'firstHalf': firstHalf,
-    'secondHalf': secondHalf,
-    'oddWeek': oddWeek,
-    'evenWeek': evenWeek,
-    'day': dayOfWeek,
-    'time': time,
-    'location': location,
-    'grsClass': grsClass,
-  };
+        'id': id,
+        'name': name,
+        'teacher': teacher,
+        'confirmed': confirmed,
+        'firstHalf': firstHalf,
+        'secondHalf': secondHalf,
+        'oddWeek': oddWeek,
+        'evenWeek': evenWeek,
+        'day': dayOfWeek,
+        'time': time,
+        'location': location,
+      };
 
   Session.fromJson(Map<String, dynamic> json)
       : id = json['id'],
@@ -104,11 +108,11 @@ class Session {
         evenWeek = json['evenWeek'],
         dayOfWeek = json['day'],
         time = List<int>.from(json['time']),
-        location = json['location'],
-        grsClass = json['grsClass'];
+        location = json['location'];
 
   String get chineseTime {
-    var timeString = '${(oddWeek & evenWeek) ? '' : oddWeek ? '单 - ' : '双 - '}周${dayMap[dayOfWeek]}第';
+    var timeString =
+        '${(oddWeek & evenWeek) ? '' : oddWeek ? '单 - ' : '双 - '}周${dayMap[dayOfWeek]}第';
     for (var i = 0; i < time.length; i++) {
       timeString += time[i].toString();
       if (i != time.length - 1) {
@@ -118,9 +122,5 @@ class Session {
     timeString.trimRight();
     timeString += '节';
     return timeString;
-  }
-
-  bool get isGrsClass {
-    return grsClass ?? false;
   }
 }

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -79,7 +79,7 @@ class CourseBriefCard extends StatelessWidget {
                         ),
                         Expanded(
                             child: Text(
-                                ' 课号：${course.id?.substring(0, 22) ?? '未知'}',
+                                ' 课号：${course.id == null ? '未知' : (course.id!.length < 22 ? course.id! : course.id!.substring(0, 22))}',
                                 style: TextStyle(
                                   fontSize: 14,
                                   fontWeight: FontWeight.normal,
@@ -124,7 +124,8 @@ class CourseBriefCard extends StatelessWidget {
                                 .withOpacity(0.5),
                           ),
                           Text(
-                              ' 成绩：${course.grade!.original} / ${course.grade!.fivePoint.toStringAsFixed(1)}',
+                              // grs is 90 / 100, ugrs is 4.0 / 5.0
+                              ' 成绩：${course.grade!.original == "" ? course.grade!.hundredPoint : course.grade!.original}  / ${course.grade!.original == "" ? 100 : course.grade!.fivePoint.toStringAsFixed(1)}',
                               style: TextStyle(
                                 fontSize: 14,
                                 fontWeight: FontWeight.normal,

--- a/lib/page/scholar/scholar_view.dart
+++ b/lib/page/scholar/scholar_view.dart
@@ -530,16 +530,17 @@ class ScholarPage extends StatelessWidget {
                 const SizedBox(height: 12),
                 Row(children: [
                   Expanded(
-                    child: SizedBox(
-                      height: 30,
-                      child: Obx(() => ListView.builder(
+                      child: SizedBox(
+                    height: 30,
+                    child: Obx(
+                      () => ListView.builder(
                           scrollDirection: Axis.horizontal,
                           itemCount: _scholarController.semesters.length,
                           itemBuilder: (context, index) {
                             final semester =
                                 _scholarController.semesters[index];
                             return Stack(children: [
-                                  Obx(() => AnimateButton(
+                              Obx(() => AnimateButton(
                                     text:
                                         '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}',
                                     onTap: () {
@@ -554,8 +555,8 @@ class ScholarPage extends StatelessWidget {
                                         ? CustomCupertinoDynamicColors.cyan
                                         : CupertinoColors.systemFill,
                                   )),
-                                  const SizedBox(width: 90),
-                                ]);
+                              const SizedBox(width: 90),
+                            ]);
                           }),
                     ),
                   )),
@@ -600,14 +601,19 @@ class ScholarPage extends StatelessWidget {
                 padding:
                     const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                 child: Column(
-                  children: [
-                    _buildGradeBrief(context),
-                    const SizedBox(height: 12),
-                    const Divider(),
-                    const SizedBox(height: 12),
-                    _buildSemester(context),
-                    //_buildHistory(context),
-                  ],
+                  children: _scholarController.scholar.username[0] == "3"
+                      ? [
+                          _buildGradeBrief(context),
+                          const SizedBox(height: 12),
+                          const Divider(),
+                          const SizedBox(height: 12),
+                          _buildSemester(context),
+                          //_buildHistory(context),
+                        ]
+                      : [
+                          const SizedBox(height: 12),
+                          _buildSemester(context),
+                        ],
                 ),
               ),
             );


### PR DESCRIPTION


初步支持新版研究生系统的课表考试和成绩，对widget进行了一些修改

当用户为研究生时：
- 区分GPA展示区域（研究生直接不展示GPA）
- 区分成绩展示（本科生五分制/研究生百分制）
- 区分课程号展示


<img width="804" alt="Untitled" src="https://github.com/Celechron/Celechron/assets/57177467/78e19f18-6be0-4776-9213-13b7fec8ef17">
<img width="797" alt="Untitled (1)" src="https://github.com/Celechron/Celechron/assets/57177467/0ed58a62-5976-483e-9266-58dea8df2aa1">
<img width="804" alt="Untitled (2)" src="https://github.com/Celechron/Celechron/assets/57177467/55bb4dee-a1a7-4fd3-8baf-eba2981a22a1">

