### PR TITLE
feat: 新增了可以自选的亮色模式和暗色模式，由于付款码无法正常运行，在设置页面注释掉了

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -61,6 +61,7 @@ class DatabaseHelper {
   final String kAllowTime = 'allowTime';
   final String kGpaStrategy = 'gpaStrategy';
   final String kPushOnGradeChange = 'pushOnGradeChange';
+  final String kBrightnessMode = 'brightnessMode';
 
   Option getOption() {
     return Option(
@@ -69,6 +70,7 @@ class DatabaseHelper {
       allowTime: getAllowTime().obs,
       gpaStrategy: getGpaStrategy().obs,
       pushOnGradeChange: getPushOnGradeChange().obs,
+      brightnessMode: getBrightnessMode().obs,
     );
   }
 
@@ -128,6 +130,19 @@ class DatabaseHelper {
 
   Future<void> setPushOnGradeChange(bool pushOnGradeChange) async {
     await optionsBox.put(kPushOnGradeChange, pushOnGradeChange);
+  }
+
+  // 保存亮度设置
+  Future<void> setBrightnessMode(int brightness) async{
+    await optionsBox.put(kBrightnessMode, brightness);
+  }
+
+  // 获取亮度设置
+  int getBrightnessMode() {
+    if (optionsBox.get(kBrightnessMode) == null) {
+      optionsBox.put(kBrightnessMode, 0);
+    }
+    return optionsBox.get(kBrightnessMode);
   }
 
   // Flow

--- a/lib/design/animate_button.dart
+++ b/lib/design/animate_button.dart
@@ -47,7 +47,7 @@ class _AnimateButtonState extends State<AnimateButton>
   Widget build(BuildContext context) {
     var isDown = false;
     var isCancel = false;
-    var brightness = MediaQuery.of(context).platformBrightness;
+    var brightness = CupertinoTheme.of(context).brightness;
 
     return GestureDetector(
       onTapDown: (_) async {

--- a/lib/design/round_rectangle_card.dart
+++ b/lib/design/round_rectangle_card.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/scheduler.dart';
 
 class RoundRectangleCard extends StatefulWidget {
   final Widget child;
@@ -63,24 +62,36 @@ class _RoundRectangleCardState extends State<RoundRectangleCard>
 
   @override
   Widget build(BuildContext context) {
+    final Brightness? brightness = CupertinoTheme.of(context).brightness;
     var isDown = false;
     var isCancel = false;
     var core = Container(
         padding: widget.padding,
+        // decoration: BoxDecoration(
+        //     borderRadius: BorderRadius.circular(12),
+        //     // In light mode, color is white; in dark mode, color is black
+        //     color: SchedulerBinding
+        //                 .instance.platformDispatcher.platformBrightness ==
+        //             Brightness.dark
+        //         ? CupertinoDynamicColor.resolve(
+        //             CupertinoColors.secondarySystemBackground, context)
+        //         : CupertinoDynamicColor.resolve(CupertinoColors.white, context),
+        //     boxShadow: SchedulerBinding
+        //                 .instance.platformDispatcher.platformBrightness ==
+        //             Brightness.dark
+        //         ? null
+        //         : widget.boxShadow),
+        // 修改了颜色控制逻辑，应该跟随应用设置而非系统设置
         decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12),
-            // In light mode, color is white; in dark mode, color is black
-            color: SchedulerBinding
-                        .instance.platformDispatcher.platformBrightness ==
-                    Brightness.dark
-                ? CupertinoDynamicColor.resolve(
-                    CupertinoColors.secondarySystemBackground, context)
-                : CupertinoDynamicColor.resolve(CupertinoColors.white, context),
-            boxShadow: SchedulerBinding
-                        .instance.platformDispatcher.platformBrightness ==
-                    Brightness.dark
-                ? null
-                : widget.boxShadow),
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: brightness == Brightness.dark
+              ? null
+              : widget.boxShadow,
+          color: brightness == Brightness.dark
+              ? CupertinoDynamicColor.resolve(
+              CupertinoColors.secondarySystemBackground, context)
+              : CupertinoDynamicColor.resolve(CupertinoColors.white, context),
+        ),
         child: widget.child);
     return widget.animate
         ? GestureDetector(

--- a/lib/design/two_line_card.dart
+++ b/lib/design/two_line_card.dart
@@ -68,7 +68,7 @@ class _TwoLineCardState extends State<TwoLineCard>
   Widget build(BuildContext context) {
     var isDown = false;
     var isCancel = false;
-    var brightness = MediaQuery.of(context).platformBrightness;
+    var brightness = CupertinoTheme.of(context).brightness;
 
     if (widget.transparent) {
       return Container(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:celechron/page/option/ecard_pay_page.dart';
 import 'package:celechron/worker/ecard_widget_messenger.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart' show Colors, Icons;
@@ -24,6 +23,8 @@ import 'package:celechron/page/option/option_view.dart';
 import 'package:celechron/model/scholar.dart';
 import 'package:celechron/worker/fuse.dart';
 import 'package:celechron/database/database_helper.dart';
+
+import 'package:celechron/page/option/option_controller.dart'; // 确保导入了控制器
 
 void main() async {
   // 从数据库读取数据
@@ -104,8 +105,10 @@ class CelechronApp extends StatefulWidget {
 class _CelechronAppState extends State<CelechronApp> {
   @override
   Widget build(BuildContext context) {
-    return GetCupertinoApp(
-      theme: const CupertinoThemeData(
+    final optionController = Get.put(OptionController());
+    return Obx(() => GetCupertinoApp(
+      theme: CupertinoThemeData(
+        brightness: optionController.brightness,
         scaffoldBackgroundColor: CupertinoColors.systemBackground,
         barBackgroundColor: CupertinoColors.systemBackground,
       ),
@@ -126,10 +129,7 @@ class _CelechronAppState extends State<CelechronApp> {
       title: 'Celechron',
       home: const HomePage(title: 'Celechron'),
       initialRoute: '/',
-      routes: {
-        '/ecardpaypage': (context) => ECardPayPage(),
-      },
-    );
+    ));
   }
 }
 
@@ -172,8 +172,8 @@ class _HomePageState extends State<HomePage> {
       tabBar: CupertinoTabBar(
         iconSize: 26,
         backgroundColor: CupertinoDynamicColor.resolve(
-                CupertinoColors.secondarySystemBackground, context)
-            .withValues(alpha: 0.5),
+            CupertinoColors.secondarySystemBackground, context)
+            .withOpacity(0.5),
         items: const <BottomNavigationBarItem>[
           BottomNavigationBarItem(
             icon: Icon(CupertinoIcons.time),

--- a/lib/model/option.dart
+++ b/lib/model/option.dart
@@ -6,6 +6,7 @@ class Option {
   RxMap<DateTime, DateTime> allowTime;
   RxInt gpaStrategy;
   RxBool pushOnGradeChange;
+  RxInt brightnessMode;
 
   Option({
     required this.workTime,
@@ -13,5 +14,6 @@ class Option {
     required this.allowTime,
     required this.gpaStrategy,
     required this.pushOnGradeChange,
+    required this.brightnessMode,
   });
 }

--- a/lib/page/option/option_controller.dart
+++ b/lib/page/option/option_controller.dart
@@ -10,12 +10,18 @@ import 'package:celechron/worker/background.dart';
 import 'package:celechron/database/database_helper.dart';
 import 'package:workmanager/workmanager.dart';
 
+import 'package:flutter/cupertino.dart';
+
 class OptionController extends GetxController {
   final option = Get.find<Option>(tag: 'option');
   final scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
   final _fuse = Get.find<Rx<Fuse>>(tag: 'fuse');
   final _db = Get.find<DatabaseHelper>(tag: 'db');
   late final RxInt allowTimeLength = option.allowTime.length.obs;
+
+  static const int BRIGHTNESS_MODE_SYSTEM = 0;
+  static const int BRIGHTNESS_MODE_LIGHT = 1;
+  static const int BRIGHTNESS_MODE_DARK = 2;
 
   @override
   void onInit() {
@@ -120,4 +126,25 @@ class OptionController extends GetxController {
     pushOnGradeChange = false;
     ECardWidgetMessenger.logout();
   }
+
+  Brightness matcher(int v){
+    switch (v) {
+      case BRIGHTNESS_MODE_SYSTEM:
+        return WidgetsBinding.instance.platformDispatcher.platformBrightness;
+      case BRIGHTNESS_MODE_LIGHT:
+        return Brightness.light;
+      case BRIGHTNESS_MODE_DARK:
+        return Brightness.dark;
+      default:
+        return WidgetsBinding.instance.platformDispatcher.platformBrightness;
+    }
+  }
+
+  Brightness get brightness => matcher(option.brightnessMode.value);
+
+  void toggleBrightness(int value) {
+    option.brightnessMode.value = value;
+    _db.setBrightnessMode(value);
+  }
+
 }

--- a/lib/page/option/option_view.dart
+++ b/lib/page/option/option_view.dart
@@ -256,6 +256,29 @@ class OptionPage extends StatelessWidget {
                     },
                   ),
                 ])),
+            // 工具
+            SliverToBoxAdapter(
+                child: CupertinoListSection.insetGrouped(
+                    additionalDividerMargin: 2,
+                    margin: _defaultMargin,
+                    header: Container(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: Text('工具', style: headerFooterTextStyle)),
+                    children: <CupertinoListTile>[
+                      CupertinoListTile(
+                        title: const Text('暗色模式'),
+                        trailing: Obx(() => Text(
+                            _optionController.option.brightnessMode.value == OptionController.BRIGHTNESS_MODE_SYSTEM
+                                ? "跟随系统设置"
+                                : _optionController.option.brightnessMode.value == OptionController.BRIGHTNESS_MODE_LIGHT
+                                ? "亮色模式"
+                                : "暗色模式"
+                        )),
+                        onTap: () => _showBrightnessPicker(context),
+                      ),
+                    ]
+                )
+            ),
             // 关于
             SliverToBoxAdapter(
               child: CupertinoListSection.insetGrouped(
@@ -289,13 +312,14 @@ class OptionPage extends StatelessWidget {
                                     const CustomLicensePage()));
                       },
                     ),
-                    CupertinoListTile(
-                      title: const Text('付款码'),
-                      trailing: const BackChervonRow(),
-                      onTap: () async {
-                        Navigator.of(context, rootNavigator: true).pushNamed('/ecardpaypage');
-                      },
-                    ),
+                    // 在上次fix之后有问题无法使用付款码
+                    // CupertinoListTile(
+                    //   title: const Text('付款码'),
+                    //   trailing: const BackChervonRow(),
+                    //   onTap: () async {
+                    //     Navigator.of(context, rootNavigator: true).pushNamed('/ecardpaypage');
+                    //   },
+                    // ),
                     CupertinoListTile(
                       title: const Text('前往项目网站'),
                       trailing: BackChervonRow(
@@ -329,7 +353,42 @@ class OptionPage extends StatelessWidget {
           ],
         )));
   }
-
+  void _showBrightnessPicker(BuildContext context) {
+    showCupertinoModalPopup(
+      context: context,
+      builder: (BuildContext context) {
+        return CupertinoActionSheet(
+          actions: <Widget>[
+            CupertinoActionSheetAction(
+              onPressed: () {
+                _optionController.toggleBrightness(OptionController.BRIGHTNESS_MODE_SYSTEM);
+                Navigator.pop(context);
+              },
+              child: Text('跟随系统设置'),
+            ),
+            CupertinoActionSheetAction(
+              onPressed: () {
+                _optionController.toggleBrightness(OptionController.BRIGHTNESS_MODE_LIGHT);
+                Navigator.pop(context);
+              },
+              child: Text('亮色模式'),
+            ),
+            CupertinoActionSheetAction(
+              onPressed: () {
+                _optionController.toggleBrightness(OptionController.BRIGHTNESS_MODE_DARK);
+                Navigator.pop(context);
+              },
+              child: Text('暗色模式'),
+            ),
+          ],
+          cancelButton: CupertinoActionSheetAction(
+            onPressed: () => Navigator.pop(context),
+            child: Text('取消'),
+          ),
+        );
+      },
+    );
+  }
   static const _defaultMargin =
       EdgeInsetsDirectional.fromSTEB(16.0, 0.0, 16.0, 10.0);
 }


### PR DESCRIPTION
在设置页面更新了工具一栏，暗色模式点击后可以选择跟随系统设置、亮色模式和暗色模式，经测试功能正常运行。
更改了一些设计文件中创建组件时Brightness选择逻辑不正确的问题。
新增了系统选项的hive存储相关内容（option和database_helper）。

p.s. 测试时发现最新的commit中付款码无法正常使用（43f9782d nosig），遂暂时在option_view.dart中注释了相关UI，未更改行为逻辑。同时main.dart第176行附近.withValues()在测试时报错无法运行原因不明，遂改回之前版本.withOpacity