### PR TITLE
修复: 长学期课程返回2个不同短学期的Session

### DIFF
--- a/lib/model/course.dart
+++ b/lib/model/course.dart
@@ -93,7 +93,19 @@ class Course {
         e.oddWeek == session.oddWeek &&
         e.evenWeek == session.evenWeek &&
         e.location == session.location &&
-        e.time.contains(session.time.first))) return false;
+        e.time.contains(session.time.first))) {
+      // 观察到修改过某短学期上课周数的长学期课程出现秋+冬两个session
+      // 合并学期类型
+      var currentSession = sessions.firstWhere((e) =>
+          e.dayOfWeek == session.dayOfWeek &&
+          e.oddWeek == session.oddWeek &&
+          e.evenWeek == session.evenWeek &&
+          e.location == session.location &&
+          e.time.contains(session.time.first));
+      currentSession.firstHalf = currentSession.firstHalf || session.firstHalf;
+      currentSession.secondHalf = currentSession.secondHalf || session.secondHalf;
+      return false;
+    }
     if (sessions.any((e) =>
         e.dayOfWeek == session.dayOfWeek &&
         e.oddWeek == session.oddWeek &&


### PR DESCRIPTION
注意到某些老师在zdbk中修改了某一段学期的上课周数（如某一周不上课）后，系统会将原本长学期（eg. 秋冬）的课在课表上返回为两个短学期（秋+冬），在Celechron中某一个短学期就会被随机丢弃，导致显示不正确的情况。
本PR通过合并所有Session的短学期类型实现了对该问题的修复。
![image](https://github.com/user-attachments/assets/54e25442-1d83-44b7-ade5-f091122db6fb)
![image](https://github.com/user-attachments/assets/0048be79-e8ac-4bda-83c9-cccf532333f2)
![image](https://github.com/user-attachments/assets/337c901e-8fe8-4172-9fe4-f2d05273442a)
![image](https://github.com/user-attachments/assets/90ec501a-e9b0-4f87-bc66-a9464b8b22ac)