### PR TITLE
修复: 针对本科生院更新的课号命名规则

### DIFF
--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -318,9 +318,10 @@ class GrsSpider implements Spider {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addGrade(e);
         //体育课
-        var key = e.id.substring(14, 22);
-        if (key.startsWith('401')) {
-          key = e.id.substring(0, 22);
+        var matchClass = RegExp(r'(\(.*\)-(.*?))-.*').firstMatch(e.id);
+        var key = matchClass?.group(2) ?? e.id.substring(14, 22);
+        if (key.startsWith('PPAE') || key.startsWith('401')) {
+          key = matchClass?.group(1) ?? e.id.substring(0, 22);
         }
         outGrades.putIfAbsent(key, () => <Grade>[]).add(e);
       }

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -296,9 +296,10 @@ class UgrsSpider implements Spider {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addGrade(e);
         // 体育课
-        var key = e.id.substring(14, 22);
-        if (key.startsWith('401')) {
-          key = e.id.substring(0, 22);
+        var matchClass = RegExp(r'(\(.*\)-(.*?))-.*').firstMatch(e.id);
+        var key = matchClass?.group(2) ?? e.id.substring(14, 22);
+        if (key.startsWith('PPAE') || key.startsWith('401')) {
+          key = matchClass?.group(1) ?? e.id.substring(0, 22);
         }
         outGrades.putIfAbsent(key, () => <Grade>[]).add(e);
       }

--- a/lib/model/course.dart
+++ b/lib/model/course.dart
@@ -18,6 +18,14 @@ class Course {
 
   bool? online = false; // only used for grs
 
+  String get realId {
+    if (id == null) return '未知';
+    var matchClass = RegExp(r'(\(.*\)-.*?)-.*').firstMatch(id!);
+    var key = matchClass?.group(1);
+    key ??= id!.length < 22 ? id : id!.substring(0, 22);
+    return key ?? '未知';
+  }
+
   Course.fromExam(ExamDto examDto) {
     id = examDto.id;
     name = examDto.name;

--- a/lib/model/grade.dart
+++ b/lib/model/grade.dart
@@ -20,6 +20,13 @@ class Grade {
   // only used for ugrs
   String get semesterId => id.length > 12 ? id.substring(1, 12) : "研究生请勿使用此函数";
 
+  String get realId {
+    var matchClass = RegExp(r'(\(.*\)-.*?)-.*').firstMatch(id);
+    var key = matchClass?.group(1);
+    key ??= id.length < 22 ? id : id.substring(0, 22);
+    return key ?? '未知';
+  }
+
   static final Map<double, double> _toFourPoint = {
     5.0: 4.3,
     4.8: 4.2,

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -79,7 +79,7 @@ class CourseBriefCard extends StatelessWidget {
                         ),
                         Expanded(
                             child: Text(
-                                ' 课号：${course.id == null ? '未知' : (course.id!.length < 22 ? course.id! : course.id!.substring(0, 22))}',
+                                ' 课号：${course.realId}',
                                 style: TextStyle(
                                   fontSize: 14,
                                   fontWeight: FontWeight.normal,

--- a/lib/page/scholar/grade_detail/grade_card.dart
+++ b/lib/page/scholar/grade_detail/grade_card.dart
@@ -166,7 +166,7 @@ class _GradeCardState extends State<GradeCard>
                                 ),
                           ),
                           Text(
-                            '${widget.grade.id.substring(0, 22)} / ${widget.grade.credit.toStringAsFixed(1)} 学分',
+                            '${widget.grade.realId} / ${widget.grade.credit.toStringAsFixed(1)} 学分',
                             style: CupertinoTheme.of(context)
                                 .textTheme
                                 .textStyle

--- a/lib/page/task/task_edit_page.dart
+++ b/lib/page/task/task_edit_page.dart
@@ -197,7 +197,7 @@ class _TaskEditPageState extends State<TaskEditPage> {
                     ),
                     if (now.type == TaskType.fixed)
                       CupertinoTextFormFieldRow(
-                        placeholder: '结束时间',
+                        placeholder: '开始时间',
                         textAlign: TextAlign.left,
                         controller: TextEditingController(
                             text:
@@ -222,6 +222,9 @@ class _TaskEditPageState extends State<TaskEditPage> {
                                       onDateTimeChanged: (DateTime newTime) {
                                         setState(() {
                                           now.startTime = newTime;
+                                          if (now.endTime.isBefore(now.startTime)) {
+                                            now.endTime = now.startTime;
+                                          }
                                         });
                                       },
                                     ),
@@ -256,6 +259,9 @@ class _TaskEditPageState extends State<TaskEditPage> {
                                     onDateTimeChanged: (DateTime newTime) {
                                       setState(() {
                                         now.endTime = newTime;
+                                        if (now.type == TaskType.fixed && now.startTime.isAfter(now.endTime)) {
+                                          now.startTime = now.endTime;
+                                        }
                                       });
                                     },
                                   ),


### PR DESCRIPTION
本科生院对课程重新进行了编码，课程原8位的编号在新的编码规则中可能不足8位或超过8位，导致显示不全或显示多余内容。
同时，修改编码规则后体育课以PPAE开头，Celechron对体育课的识别可能有误。
本PR通过将字符串切片改写为正则表达式的方式修复了这个问题。

![image](https://github.com/user-attachments/assets/b97eb86a-e894-4042-b2b2-ed1cb673dbae)

