### PR TITLE
fix: 更加优雅的解决了校历未出考试周时间待定的问题

### DIFF
--- a/lib/model/exam.dart
+++ b/lib/model/exam.dart
@@ -45,22 +45,6 @@ class Exam {
   }*/
 
   Exam._fromZdbk(this.id, this.name, Map<String, dynamic> json, this.type) {
-    // 2025-2026秋冬学期的考试时间格式与其他学期不同
-    if(this.id.contains("2025-2026-1")) {
-      switch (type) {
-        case ExamType.midterm:
-          time = [DateTime(2077, 11, 4, 5, 14), DateTime(2077, 11, 4, 7, 14)];
-          location = json['qzjsmc'];
-          seat = json['qzzwxh'];
-          break;
-        case ExamType.finalExam:
-          time = [DateTime(2077, 11, 4, 5, 14), DateTime(2077, 11, 4, 7, 14)];
-          location = json['jsmc'];
-          seat = json['zwxh'];
-          break;
-      }
-    }
-
     switch (type) {
       case ExamType.midterm:
         time = TimeHelper.parseExamDateTime(json['qzkssj']);
@@ -106,7 +90,7 @@ class Exam {
 
   get chineseTime => TimeHelper.chineseTime(time[0], time[1]);
 
-  get chineseDate => '${time[0].month}月${time[0].day}日';
+  get chineseDate => TimeHelper.chineseDay(time[0]).replaceAll(" ", "");
 }
 
 enum ExamType { midterm, finalExam }

--- a/lib/utils/time_helper.dart
+++ b/lib/utils/time_helper.dart
@@ -3,18 +3,33 @@ import 'package:celechron/utils/utils.dart';
 class TimeHelper {
   static List<DateTime> parseExamDateTime(String datetimeStr) {
     // Input format: 2021年01月22日(08:00-10:00)
-    var date =
-        '${datetimeStr.substring(0, 4)}${datetimeStr.substring(5, 7)}${datetimeStr.substring(8, 10)}T';
-    var timeBegin = datetimeStr.substring(12, 17);
-    var timeEnd = datetimeStr.substring(18, 23);
+    String date, timeBegin, timeEnd;
+    if (datetimeStr.contains("年") ?? false) {
+      date =
+          '${datetimeStr.substring(0, 4)}${datetimeStr.substring(5, 7)}${datetimeStr.substring(8, 10)}T';
+      timeBegin = datetimeStr.substring(12, 17);
+      timeEnd = datetimeStr.substring(18, 23);
+    } else {
+      // 校历未出时zdbk不会有具体日期 使用1970代替
+      var datePat = RegExp("第(\\d+)天\\((.+)-(.+)\\)").firstMatch(datetimeStr);
+      date = '197001${datePat?.group(1)?.padLeft(2, '0') ?? "14"}T';
+      timeBegin = datePat?.group(2) ?? "05:14";
+      timeEnd = datePat?.group(3) ?? "07:14";
+    }
     return [DateTime.parse(date + timeBegin), DateTime.parse(date + timeEnd)];
   }
 
   static String chineseDateTime(DateTime dateTime) {
+    if (dateTime.year == 1970) {
+      return '考试周第 ${dateTime.day} 天 ${dateTime.hour}:${dateTime.minute.toString().padLeft(2, '0')}';
+    }
     return '${dateTime.year} 年 ${dateTime.month} 月 ${dateTime.day} 日 ${dateTime.hour}:${dateTime.minute.toString().padLeft(2, '0')}';
   }
 
   static String chineseDate(DateTime date) {
+    if (date.year == 1970) {
+      return '考试周第 ${date.day} 天';
+    }
     return '${date.year} 年 ${date.month} 月 ${date.day} 日';
   }
 
@@ -23,8 +38,10 @@ class TimeHelper {
   }
 
   static String chineseDay(DateTime date) {
-    var dayStr = '${date.month} 月 ${date.day} 日 ';
-    return dayStr;
+    if (date.year == 1970) {
+      return '考试周第 ${date.day} 天 ';
+    }
+    return '${date.month} 月 ${date.day} 日 ';
   }
 
   static String toHM(Duration duration) {


### PR DESCRIPTION
使用极其恶臭的日期代替未知的考试周显得不够优雅，因此：
1、通过将校历待定的考试周日期定义在1970年1月，日期x为考试周第x天，时间不变保存考试时间
2、显示中文字符时动态替换为 考试周第x天
上述解决方案已经通过本 Pull Request 提交。