### PR TITLE
fix: 课程时间超出预设值时，使用默认值

### DIFF
--- a/lib/model/semester.dart
+++ b/lib/model/semester.dart
@@ -1,6 +1,7 @@
 import 'package:celechron/model/exams_dto.dart';
 import 'package:celechron/model/period.dart';
 import 'package:celechron/utils/gpa_helper.dart';
+import 'package:celechron/utils/list_ext.dart';
 import 'course.dart';
 import 'exam.dart';
 import 'grade.dart';
@@ -260,10 +261,10 @@ class Semester {
               location: session.location ?? "未知",
               summary: session.name,
               startTime: day.add(
-                  _sessionToTime[session.time.first].firstOrNull ??
+                  _sessionToTime.at(session.time.first)?.firstOrNull ??
                       Duration.zero),
               endTime: day.add(
-                  _sessionToTime[session.time.last].lastOrNull ??
+                  _sessionToTime.at(session.time.last)?.lastOrNull ??
                       Duration.zero));
           periods.add(period);
         }

--- a/lib/utils/list_ext.dart
+++ b/lib/utils/list_ext.dart
@@ -1,0 +1,8 @@
+extension OptionalListExtension<T> on List<T> {
+  T? at(int index) {
+    if (index >= 0 && index < length) {
+      return this[index];
+    }
+    return null;
+  }
+}


### PR DESCRIPTION
将列表索引改为可空返回，传递 nullable 从而允许使用默认值，避免报错