### PR TITLE
bugfix: 修复国际课程学分不计入学期学分的bug

### DIFF
--- a/lib/model/grade.dart
+++ b/lib/model/grade.dart
@@ -15,7 +15,7 @@ class Grade {
   late bool creditIncluded;
 
   // 获得的学分（挂科、不计学分的不计）
-  double get earnedCredit => (creditIncluded && fivePoint != 0) ? credit : 0.0;
+  double get earnedCredit => (creditIncluded && (fivePoint != 0 || id.contains('xtwkc'))) ? credit : 0.0;
 
   // only used for ugrs
   String get semesterId => id.length > 12 ? id.substring(1, 12) : "研究生请勿使用此函数";


### PR DESCRIPTION
见 [国际课程导入的学分未计入学年学分 #58](https://github.com/Celechron/Celechron/issues/58)
