### PR TITLE
feat: 自动更新 Credits Page 当中的 Contributors 列表

### DIFF
--- a/lib/http/github_service.dart
+++ b/lib/http/github_service.dart
@@ -28,20 +28,19 @@ class GitHubService {
       request.headers.add('Accept', 'application/vnd.github+json');
       request.headers.add('X-GitHub-Api-Version', '2022-11-28');
 
-      var response = await request.close().timeout(
-          const Duration(seconds: 10),
+      var response = await request.close().timeout(const Duration(seconds: 10),
           onTimeout: () => throw ExceptionWithMessage("请求超时"));
 
       if (response.statusCode == 200) {
         var jsonString = await response.transform(utf8.decoder).join();
         var data = jsonDecode(jsonString) as List<dynamic>;
         var logins = data.map((item) => item['login'] as String).toList();
-        
+
         // 如果抓取到的列表为空，返回默认作者名单
         if (logins.isEmpty) {
           return Tuple(null, defaultContributors);
         }
-        
+
         return Tuple(null, logins);
       } else {
         // 请求失败时返回默认作者名单
@@ -51,11 +50,9 @@ class GitHubService {
       }
     } catch (e) {
       // 网络错误或其他异常时返回默认作者名单
-      var exception = e is SocketException
-          ? ExceptionWithMessage("网络错误")
-          : e as Exception;
+      var exception =
+          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
       return Tuple(exception, defaultContributors);
     }
   }
 }
-

--- a/lib/page/option/credits_page.dart
+++ b/lib/page/option/credits_page.dart
@@ -68,7 +68,7 @@ class _CreditsPageState extends State<CreditsPage> {
     List<Widget> rows = [];
     for (int i = 0; i < _contributors.length; i += 2) {
       List<Widget> children = [];
-      
+
       // 第一个contributor
       children.add(
         Expanded(


### PR DESCRIPTION
## 功能描述

实现 #88 提到的 contributors 列表的自动更新功能，从 GitHub API 获取最新的贡献者列表，并保持原有的排版样式。

[API 文档](https://docs.github.com/zh/rest/repos/repos?apiVersion=2022-11-28#list-repository-contributors)

## 改动内容

### 新增文件

- `lib/http/github_service.dart` - GitHub API 服务类，用于获取仓库 contributors 列表

### 修改文件

- `lib/page/option/credits_page.dart` - 将 `CreditsPage` 从 `StatelessWidget` 改为 `StatefulWidget`，支持异步加载 contributors

## 技术实现

### GitHubService

- 使用 GitHub REST API v3 获取 contributors 列表
- 实现了错误处理和默认值 fallback 机制
- 当 API 请求失败或返回空列表时，返回预设的默认作者名单

**默认作者名单**：与原有版本名单一致
```dart
['nosig', 'iotang', 'cxz66666', 'Azuk 443', 'FoggyDawn', 'poormonitor', 'heddxh']
```

### CreditsPage 改动

1. **状态管理**：从 `StatelessWidget` 改为 `StatefulWidget`
2. **异步加载**：在 `initState` 中调用 API 获取 contributors
3. **UI 更新**：
   - 加载时显示 `CupertinoActivityIndicator`
   - 加载完成后动态渲染 contributors 列表
   - 保持原有的排版样式（每行 2 个名字，行间距 12px）
   - 保持 `version` 字段的获取和处理方式不变

### 排版逻辑

- 自动将 contributors 列表按每行 2 个进行排版
- 如果是奇数个，最后一行只显示一个名字
- 行与行之间保持 12px 间距

## 注意事项

- GitHub API 有速率限制（未认证请求：60 次/小时）
- 如果 contributors 数量较多，排版会自动换行
- 默认作者名单在 `GitHubService._defaultContributors` 中维护，如需更新请修改该常量


## 截图

测试平台:

- [x]  iOS 18.5 iPhone 15

无网络时，返回默认名单
<img width="492" height="469" alt="available at：" src="https://github.com/user-attachments/assets/3cf9efc7-cfab-4ced-a65c-d3498c8caab2" />

<img width="373" height="828" alt="Celechron" src="https://github.com/user-attachments/assets/d21b59ee-bcb2-4d4d-a86b-847612a9d938" />

有网络时，返回 api 抓取名单
<img width="372" height="817" alt="Celechron" src="https://github.com/user-attachments/assets/c64a2454-30d5-4b67-96b9-980b4f6fbd8d" />

