### PR TITLE
feat: 增加退出登录二次确认弹窗

### DIFF
--- a/lib/page/option/option_view.dart
+++ b/lib/page/option/option_view.dart
@@ -92,8 +92,7 @@ class OptionPage extends StatelessWidget {
                                   builder: (BuildContext dialogContext) {
                                     return CupertinoAlertDialog(
                                       title: const Text('退出登录'),
-                                      content:
-                                          const Text('确定要退出当前账号吗？'),
+                                      content: const Text('确定要退出当前账号吗？'),
                                       actions: [
                                         CupertinoDialogAction(
                                           child: const Text('取消'),


### PR DESCRIPTION
完成 issue #94 与 #11 当中提到的登录二次确认弹窗功能

## 预览截图

<img width="328" height="215" alt="自定义课程代码映射" src="https://github.com/user-attachments/assets/b17d7720-a7db-47e3-837e-1512c55daab9" />

<img width="395" height="338" alt="自定义课程代码映射" src="https://github.com/user-attachments/assets/4d1ea063-b077-4fe2-9e5d-b594252a6859" />
