### PR TITLE
Fix: 修复本研课程互通中 ugrs 抓取研究生课程信息问题

### DIFF
--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -263,7 +263,7 @@ class UgrsSpider implements Spider {
             _grsNew.getTimetable(_httpClient, yearEnroll, 13).then((value) {
           for (var e in value.item2) {
             outSemesters[semesterIndexMap['$yearStr-1']!]
-                .addSession(e, '$yearStr-1');
+                .addSession(e, '$yearStr-1', true);
           }
           return value.item1?.toString();
         }).catchError((e) => e.toString()));
@@ -271,7 +271,7 @@ class UgrsSpider implements Spider {
             _grsNew.getTimetable(_httpClient, yearEnroll, 14).then((value) {
           for (var e in value.item2) {
             outSemesters[semesterIndexMap['$yearStr-1']!]
-                .addSession(e, '$yearStr-1');
+                .addSession(e, '$yearStr-1', true);
           }
           return value.item1?.toString();
         }).catchError((e) => e.toString()));
@@ -279,7 +279,7 @@ class UgrsSpider implements Spider {
             _grsNew.getTimetable(_httpClient, yearEnroll, 11).then((value) {
           for (var e in value.item2) {
             outSemesters[semesterIndexMap['$yearStr-2']!]
-                .addSession(e, '$yearStr-2');
+                .addSession(e, '$yearStr-2', true);
           }
           return value.item1?.toString();
         }).catchError((e) => e.toString()));
@@ -287,7 +287,7 @@ class UgrsSpider implements Spider {
             _grsNew.getTimetable(_httpClient, yearEnroll, 12).then((value) {
           for (var e in value.item2) {
             outSemesters[semesterIndexMap['$yearStr-2']!]
-                .addSession(e, '$yearStr-2');
+                .addSession(e, '$yearStr-2', true);
           }
           return value.item1?.toString();
         }).catchError((e) => e.toString()));

--- a/lib/http/zjuServices/grs_new.dart
+++ b/lib/http/zjuServices/grs_new.dart
@@ -99,9 +99,10 @@ class GrsNew {
         throw ExceptionWithMessage('获取成绩api错误，错误信息为 ${result["message"]}');
       }
 
-      final records = result["result"] as Map<String, dynamic>;
-
-      final rawGrades = records["xxjhnList"] as List<dynamic>;
+      final rawGrades = (result["result"]?["xxjhnList"] as List?) ?? [];
+      if (rawGrades.isEmpty) {
+        return Tuple(null, <Grade>[]);
+      }
       List<Grade> grades = [];
 
       for (var rawGradeDyn in rawGrades) {

--- a/lib/http/zjuServices/grs_new.dart
+++ b/lib/http/zjuServices/grs_new.dart
@@ -233,22 +233,19 @@ class GrsNew {
   }
 
   /// 根据课程列表 sessions，通过研究生教务系统课程详情 API 补全每门课程的学分、上课方式（线上/线下）、课程类型等详细信息。
-  /// 
+  ///
   /// 参数说明：
   /// [httpClient] - Dart 的 HttpClient 实例，用于发起 API 请求。
   /// [year] - 学年（如 2023），等同于 API 参数 xns。
   /// [semester] - 学期代码，Semester 枚举值（11/12/13/14/15/16），等同于 API 参数 pkxq。
   /// [sessions] - 课程 Session 对象列表，需要补全详细信息的课程列表。
-  /// 
+  ///
   /// 用法示例：
   ///   await _fetchCourseDetails(httpClient, 2023, 13, sessions);
   ///
   /// 注意：必须先登录获取 _token，否则不会进行任何操作。
-  Future<void> _fetchCourseDetails(
-      HttpClient httpClient,
-      int year,
-      int semester,
-      List<Session> sessions) async {
+  Future<void> _fetchCourseDetails(HttpClient httpClient, int year,
+      int semester, List<Session> sessions) async {
     if (_token == null) return;
 
     // 将 sessions 按课程 id 归类，以便批量更新同一课程可能出现的多条 session 信息
@@ -271,16 +268,17 @@ class GrsNew {
       try {
         // Build URL with parameters
         // 对应研究生教务系统的查询全校开课情况接口
-        String url = "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryKcbjDetailInfoPage?";
+        String url =
+            "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryKcbjDetailInfoPage?";
         url += "&xns=$year";
         url += "&xqMc=${Uri.encodeComponent(semesterName)}"; // 学期名称
         url += "&kcbh=${Uri.encodeComponent(sessionId)}"; // 课程ID
-        url += "&kcmc=${Uri.encodeComponent(courseSessions.first.name)}"; // 课程名称
+        url +=
+            "&kcmc=${Uri.encodeComponent(courseSessions.first.name)}"; // 课程名称
         url += "&zjjsJzgId=${Uri.encodeComponent(teacherId)}"; // 教师ID
-        var req = await httpClient
-            .getUrl(Uri.parse(url))
-            .timeout(const Duration(seconds: 8),
-                onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        var req = await httpClient.getUrl(Uri.parse(url)).timeout(
+            const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("request timeout"));
         req.headers.add("X-Access-Token", _token!);
         var res = await req.close().timeout(const Duration(seconds: 8),
             onTimeout: () => throw ExceptionWithMessage("request timeout"));

--- a/lib/http/zjuServices/zdbk.dart
+++ b/lib/http/zjuServices/zdbk.dart
@@ -201,7 +201,9 @@ class Zdbk {
       if (timetableJson == null) throw ExceptionWithMessage("无法解析");
 
       var sessions = (jsonDecode(timetableJson) as List<dynamic>)
-          .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
+          .where((e) =>
+              e['kcb'] != null &&
+              (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
           .map((e) => Session.fromZdbk(e));
       _db?.setCachedWebPage('zdbk_Timetable$year$semester', timetableJson);
       return Tuple(null, sessions);
@@ -212,7 +214,9 @@ class Zdbk {
           exception,
           (jsonDecode((_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
                   '[]')) as List<dynamic>)
-              .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
+              .where((e) =>
+                  e['kcb'] != null &&
+                  (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
               .map((e) => Session.fromZdbk(e)));
     }
   }

--- a/lib/http/zjuServices/zdbk.dart
+++ b/lib/http/zjuServices/zdbk.dart
@@ -201,7 +201,7 @@ class Zdbk {
       if (timetableJson == null) throw ExceptionWithMessage("无法解析");
 
       var sessions = (jsonDecode(timetableJson) as List<dynamic>)
-          .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
+          .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
           .map((e) => Session.fromZdbk(e));
       _db?.setCachedWebPage('zdbk_Timetable$year$semester', timetableJson);
       return Tuple(null, sessions);
@@ -212,7 +212,7 @@ class Zdbk {
           exception,
           (jsonDecode((_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
                   '[]')) as List<dynamic>)
-              .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
+              .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1")) // 本科生教务网忽略所有研究生课程，即忽略字段sfyjskc为"1"的课程
               .map((e) => Session.fromZdbk(e)));
     }
   }

--- a/lib/http/zjuServices/zdbk.dart
+++ b/lib/http/zjuServices/zdbk.dart
@@ -201,7 +201,7 @@ class Zdbk {
       if (timetableJson == null) throw ExceptionWithMessage("无法解析");
 
       var sessions = (jsonDecode(timetableJson) as List<dynamic>)
-          .where((e) => e['kcb'] != null)
+          .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
           .map((e) => Session.fromZdbk(e));
       _db?.setCachedWebPage('zdbk_Timetable$year$semester', timetableJson);
       return Tuple(null, sessions);
@@ -212,7 +212,7 @@ class Zdbk {
           exception,
           (jsonDecode((_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
                   '[]')) as List<dynamic>)
-              .where((e) => e['kcb'] != null)
+              .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
               .map((e) => Session.fromZdbk(e)));
     }
   }

--- a/lib/model/calendar_to_system.dart
+++ b/lib/model/calendar_to_system.dart
@@ -387,9 +387,7 @@ class CalendarToSystemManager {
   Future<void> resyncCalendarEvents(BuildContext context) async {
     try {
       if (!await requestPermissions()) {
-        if (context.mounted) {
-          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
-        }
+        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
         return;
       }
 
@@ -401,19 +399,13 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        if (context.mounted) {
-          _showAlert(context, '重新同步成功',
-              '已重新同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
-        }
+        _showAlert(context, '重新同步成功',
+            '已重新同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
       } else {
-        if (context.mounted) {
-          _showAlert(context, '重新同步失败', '无法重新同步课程到系统日历');
-        }
+        _showAlert(context, '重新同步失败', '无法重新同步课程到系统日历');
       }
     } catch (e) {
-      if (context.mounted) {
-        _showAlert(context, '错误', '重新同步时出错: $e', isError: true);
-      }
+      _showAlert(context, '错误', '重新同步时出错: $e', isError: true);
     }
   }
 
@@ -422,17 +414,13 @@ class CalendarToSystemManager {
       BuildContext context, String semesterName) async {
     try {
       if (!await requestPermissions()) {
-        if (context.mounted) {
-          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
-        }
+        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
         return;
       }
 
       var semester = getSemesterByName(semesterName);
       if (semester == null) {
-        if (context.mounted) {
-          _showAlert(context, '错误', '未找到指定的学期');
-        }
+        _showAlert(context, '错误', '未找到指定的学期');
         return;
       }
 
@@ -446,19 +434,13 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        if (context.mounted) {
-          _showAlert(context, '同步成功',
-              '已同步 $semesterName 的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
-        }
+        _showAlert(context, '同步成功',
+            '已同步 $semesterName 的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
       } else {
-        if (context.mounted) {
-          _showAlert(context, '同步失败', '无法同步 $semesterName 的课程');
-        }
+        _showAlert(context, '同步失败', '无法同步 $semesterName 的课程');
       }
     } catch (e) {
-      if (context.mounted) {
-        _showAlert(context, '错误', '同步时出错: $e', isError: true);
-      }
+      _showAlert(context, '错误', '同步时出错: $e', isError: true);
     }
   }
 
@@ -466,9 +448,7 @@ class CalendarToSystemManager {
   Future<void> syncAllSemesters(BuildContext context) async {
     try {
       if (!await requestPermissions()) {
-        if (context.mounted) {
-          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
-        }
+        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
         return;
       }
 
@@ -482,19 +462,13 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        if (context.mounted) {
-          _showAlert(context, '同步成功',
-              '已同步所有学期的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
-        }
+        _showAlert(context, '同步成功',
+            '已同步所有学期的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
       } else {
-        if (context.mounted) {
-          _showAlert(context, '同步失败', '无法同步所有学期的课程');
-        }
+        _showAlert(context, '同步失败', '无法同步所有学期的课程');
       }
     } catch (e) {
-      if (context.mounted) {
-        _showAlert(context, '错误', '同步时出错: $e', isError: true);
-      }
+      _showAlert(context, '错误', '同步时出错: $e', isError: true);
     }
   }
 
@@ -616,17 +590,13 @@ class CalendarToSystemManager {
     if (enabled) {
       // 如果要开启同步，先检查权限
       if (!await requestPermissions()) {
-        if (context.mounted) {
-          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
-        }
+        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
         return;
       }
 
       // 检查是否已登录
       if (!scholar.isLogan) {
-        if (context.mounted) {
-          _showAlert(context, '提示', '请先登录后再开启日历同步功能');
-        }
+        _showAlert(context, '提示', '请先登录后再开启日历同步功能');
         return;
       }
 
@@ -636,18 +606,14 @@ class CalendarToSystemManager {
       if (syncSuccess) {
         _calendarSyncEnabled.value = true;
         var stats = getSyncStats();
-        if (context.mounted) {
-          _showAlert(context, '同步成功',
-              '已同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
-        }
+        _showAlert(context, '同步成功',
+            '已同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
       } else {
         // For iOS, show different message
-        if (context.mounted) {
-          if (Platform.isIOS) {
-            _showAlert(context, '同步失败', '无法同步课程到系统日历，从日历中移除Google账户后重试');
-          } else {
-            _showAlert(context, '同步失败', '无法同步课程到系统日历，请检查权限和网络连接');
-          }
+        if (Platform.isIOS) {
+          _showAlert(context, '同步失败', '无法同步课程到系统日历，从日历中移除Google账户后重试');
+        } else {
+          _showAlert(context, '同步失败', '无法同步课程到系统日历，请检查权限和网络连接');
         }
       }
     } else {
@@ -658,18 +624,12 @@ class CalendarToSystemManager {
       try {
         bool deleteSuccess = await deleteCelechronCalendar();
         if (deleteSuccess) {
-          if (context.mounted) {
-            _showAlert(context, '成功', '日历同步功能已关闭，已删除课表数据和Celechron日历');
-          }
+          _showAlert(context, '成功', '日历同步功能已关闭，已删除课表数据和Celechron日历');
         } else {
-          if (context.mounted) {
-            _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时遇到问题');
-          }
+          _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时遇到问题');
         }
       } catch (e) {
-        if (context.mounted) {
-          _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时出错: $e');
-        }
+        _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时出错: $e');
       }
     }
   }

--- a/lib/model/calendar_to_system.dart
+++ b/lib/model/calendar_to_system.dart
@@ -387,7 +387,9 @@ class CalendarToSystemManager {
   Future<void> resyncCalendarEvents(BuildContext context) async {
     try {
       if (!await requestPermissions()) {
-        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        if (context.mounted) {
+          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        }
         return;
       }
 
@@ -399,13 +401,19 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        _showAlert(context, '重新同步成功',
-            '已重新同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        if (context.mounted) {
+          _showAlert(context, '重新同步成功',
+              '已重新同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        }
       } else {
-        _showAlert(context, '重新同步失败', '无法重新同步课程到系统日历');
+        if (context.mounted) {
+          _showAlert(context, '重新同步失败', '无法重新同步课程到系统日历');
+        }
       }
     } catch (e) {
-      _showAlert(context, '错误', '重新同步时出错: $e', isError: true);
+      if (context.mounted) {
+        _showAlert(context, '错误', '重新同步时出错: $e', isError: true);
+      }
     }
   }
 
@@ -414,13 +422,17 @@ class CalendarToSystemManager {
       BuildContext context, String semesterName) async {
     try {
       if (!await requestPermissions()) {
-        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        if (context.mounted) {
+          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        }
         return;
       }
 
       var semester = getSemesterByName(semesterName);
       if (semester == null) {
-        _showAlert(context, '错误', '未找到指定的学期');
+        if (context.mounted) {
+          _showAlert(context, '错误', '未找到指定的学期');
+        }
         return;
       }
 
@@ -434,13 +446,19 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        _showAlert(context, '同步成功',
-            '已同步 $semesterName 的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        if (context.mounted) {
+          _showAlert(context, '同步成功',
+              '已同步 $semesterName 的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        }
       } else {
-        _showAlert(context, '同步失败', '无法同步 $semesterName 的课程');
+        if (context.mounted) {
+          _showAlert(context, '同步失败', '无法同步 $semesterName 的课程');
+        }
       }
     } catch (e) {
-      _showAlert(context, '错误', '同步时出错: $e', isError: true);
+      if (context.mounted) {
+        _showAlert(context, '错误', '同步时出错: $e', isError: true);
+      }
     }
   }
 
@@ -448,7 +466,9 @@ class CalendarToSystemManager {
   Future<void> syncAllSemesters(BuildContext context) async {
     try {
       if (!await requestPermissions()) {
-        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        if (context.mounted) {
+          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        }
         return;
       }
 
@@ -462,13 +482,19 @@ class CalendarToSystemManager {
 
       if (syncSuccess) {
         var stats = getSyncStats();
-        _showAlert(context, '同步成功',
-            '已同步所有学期的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        if (context.mounted) {
+          _showAlert(context, '同步成功',
+              '已同步所有学期的 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        }
       } else {
-        _showAlert(context, '同步失败', '无法同步所有学期的课程');
+        if (context.mounted) {
+          _showAlert(context, '同步失败', '无法同步所有学期的课程');
+        }
       }
     } catch (e) {
-      _showAlert(context, '错误', '同步时出错: $e', isError: true);
+      if (context.mounted) {
+        _showAlert(context, '错误', '同步时出错: $e', isError: true);
+      }
     }
   }
 
@@ -590,13 +616,17 @@ class CalendarToSystemManager {
     if (enabled) {
       // 如果要开启同步，先检查权限
       if (!await requestPermissions()) {
-        _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        if (context.mounted) {
+          _showAlert(context, '权限获取失败', '请在系统设置中手动开启日历权限');
+        }
         return;
       }
 
       // 检查是否已登录
       if (!scholar.isLogan) {
-        _showAlert(context, '提示', '请先登录后再开启日历同步功能');
+        if (context.mounted) {
+          _showAlert(context, '提示', '请先登录后再开启日历同步功能');
+        }
         return;
       }
 
@@ -606,14 +636,18 @@ class CalendarToSystemManager {
       if (syncSuccess) {
         _calendarSyncEnabled.value = true;
         var stats = getSyncStats();
-        _showAlert(context, '同步成功',
-            '已同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        if (context.mounted) {
+          _showAlert(context, '同步成功',
+              '已同步 ${stats['syncedCourseCount']} 门课程，共计 ${stats['syncedEventCount']} 个日程');
+        }
       } else {
         // For iOS, show different message
-        if (Platform.isIOS) {
-          _showAlert(context, '同步失败', '无法同步课程到系统日历，从日历中移除Google账户后重试');
-        } else {
-          _showAlert(context, '同步失败', '无法同步课程到系统日历，请检查权限和网络连接');
+        if (context.mounted) {
+          if (Platform.isIOS) {
+            _showAlert(context, '同步失败', '无法同步课程到系统日历，从日历中移除Google账户后重试');
+          } else {
+            _showAlert(context, '同步失败', '无法同步课程到系统日历，请检查权限和网络连接');
+          }
         }
       }
     } else {
@@ -624,12 +658,18 @@ class CalendarToSystemManager {
       try {
         bool deleteSuccess = await deleteCelechronCalendar();
         if (deleteSuccess) {
-          _showAlert(context, '成功', '日历同步功能已关闭，已删除课表数据和Celechron日历');
+          if (context.mounted) {
+            _showAlert(context, '成功', '日历同步功能已关闭，已删除课表数据和Celechron日历');
+          }
         } else {
-          _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时遇到问题');
+          if (context.mounted) {
+            _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时遇到问题');
+          }
         }
       } catch (e) {
-        _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时出错: $e');
+        if (context.mounted) {
+          _showAlert(context, '成功', '日历同步功能已关闭，但删除日历时出错: $e');
+        }
       }
     }
   }

--- a/lib/model/course.dart
+++ b/lib/model/course.dart
@@ -17,6 +17,7 @@ class Course {
   List<Exam> exams = [];
 
   bool? online = false; // only used for grs
+  String? type; // GRS-specific course type (e.g., "专业学位课")
 
   String get realId {
     if (id == null) return '未知';
@@ -40,6 +41,15 @@ class Course {
     name = session.name;
     confirmed = session.confirmed;
     teacher = session.teacher;
+    if (session.credit != null) {
+      credit = session.credit!;
+    }
+    if (session.online != null) {
+      online = session.online!;
+    }
+    if (session.type != null) {
+      type = session.type!;
+    }
     sessions.add(session);
   }
   // used for zdbk
@@ -97,6 +107,16 @@ class Course {
     id ??= session.id;
     session.id = id;
     teacher ??= session.teacher;
+    // Transfer metadata from Session if available
+    if (session.credit != null && credit == 0.0) {
+      credit = session.credit!;
+    }
+    if (session.online != null && online == false) {
+      online = session.online!;
+    }
+    if (session.type != null && type == null) {
+      type = session.type!;
+    }
     if (sessions.any((e) =>
         e.dayOfWeek == session.dayOfWeek &&
         e.oddWeek == session.oddWeek &&
@@ -162,6 +182,8 @@ class Course {
       'teacher': teacher,
       'sessions': sessions.map((e) => e.toJson()).toList(),
       'exams': exams.map((e) => e.toJson()).toList(),
+      'online': online,
+      'type': type,
     };
   }
 
@@ -179,5 +201,7 @@ class Course {
             .toList(),
         exams = (json['exams'] as List<dynamic>)
             .map((e) => Exam.fromJson(e as Map<String, dynamic>))
-            .toList();
+            .toList(),
+        online = json['online'] as bool?,
+        type = json['type'] as String?;
 }

--- a/lib/model/session.dart
+++ b/lib/model/session.dart
@@ -2,6 +2,7 @@ class Session {
   String? id;
   late String name;
   late String teacher;
+  String? teacherId; // GRS teacher ID for detail API calls
   String? location;
   bool confirmed;
   int dayOfWeek;
@@ -22,6 +23,11 @@ class Session {
   // 自定义单双周。目前仅在研究生课程中出现。
   bool customRepeat = false;
   List<int> customRepeatWeeks = [];
+
+  // GRS course metadata (used when creating Course)
+  double? credit;
+  bool? online;
+  String? type;
 
   String get semesterId => id!.substring(1, 12);
   bool get showOnTimetable => !customRepeat || customRepeatWeeks.length >= 3;
@@ -92,6 +98,7 @@ class Session {
         'id': id,
         'name': name,
         'teacher': teacher,
+        'teacherId': teacherId,
         'confirmed': confirmed,
         'firstHalf': firstHalf,
         'secondHalf': secondHalf,
@@ -102,12 +109,16 @@ class Session {
         'location': location,
         'customRepeat': customRepeat,
         'customRepeatWeeks': customRepeatWeeks,
+        'credit': credit,
+        'online': online,
+        'type': type,
       };
 
   Session.fromJson(Map<String, dynamic> json)
       : id = json['id'],
         name = json['name'],
         teacher = json['teacher'],
+        teacherId = json['teacherId'] as String?,
         confirmed = json['confirmed'],
         firstHalf = json['firstHalf'],
         secondHalf = json['secondHalf'],
@@ -117,7 +128,10 @@ class Session {
         time = List<int>.from(json['time']),
         location = json['location'],
         customRepeat = json['customRepeat'] ?? false,
-        customRepeatWeeks = List<int>.from(json['customRepeatWeeks'] ?? []);
+        customRepeatWeeks = List<int>.from(json['customRepeatWeeks'] ?? []),
+        credit = json['credit'] as double?,
+        online = json['online'] as bool?,
+        type = json['type'] as String?;
 
   String get chineseTime {
     var timeString =

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -56,7 +56,7 @@ class CourseBriefCard extends StatelessWidget {
                             ),
                           ),
                           Text(
-                              course.credit > 0 
+                              course.credit > 0
                                   ? '  ${course.credit.toStringAsFixed(1)} 学分'
                                   : '  待更新',
                               style: CupertinoTheme.of(context)

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -55,11 +55,10 @@ class CourseBriefCard extends StatelessWidget {
                               ),
                             ),
                           ),
-                          // 显示学分，如果没有则显示"学分未知"
                           Text(
                               course.credit > 0 
                                   ? '  ${course.credit.toStringAsFixed(1)} 学分'
-                                  : '  学分未知',
+                                  : '  待更新',
                               style: CupertinoTheme.of(context)
                                   .textTheme
                                   .textStyle

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -140,6 +140,58 @@ class CourseBriefCard extends StatelessWidget {
                               )),
                         }
                       ]),
+                      // 添加online和type字段的显示
+                      // 当课程为线上课程(online == true)或具有特定课程类型(type != null)时显示
+                      if (course.online == true || course.type != null) ...{
+                        // const SizedBox(height: 4.0),
+                        Row(children: [
+                          if (course.online == true) ...{
+                            Icon(
+                              CupertinoIcons.globe,
+                              size: 14,
+                              color: CupertinoTheme.of(context)
+                                  .textTheme
+                                  .textStyle
+                                  .color!
+                                  .withValues(alpha: 0.5),
+                            ),
+                            Text(' 线上课程',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.normal,
+                                  color: CupertinoTheme.of(context)
+                                      .textTheme
+                                      .textStyle
+                                      .color!
+                                      .withValues(alpha: 0.75),
+                                  overflow: TextOverflow.ellipsis,
+                                )),
+                            const SizedBox(width: 8.0),
+                          },
+                          if (course.type != null) ...{
+                            Icon(
+                              CupertinoIcons.tag,
+                              size: 14,
+                              color: CupertinoTheme.of(context)
+                                  .textTheme
+                                  .textStyle
+                                  .color!
+                                  .withValues(alpha: 0.5),
+                            ),
+                            Text(' ${course.type}',
+                                style: TextStyle(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.normal,
+                                  color: CupertinoTheme.of(context)
+                                      .textTheme
+                                      .textStyle
+                                      .color!
+                                      .withValues(alpha: 0.75),
+                                  overflow: TextOverflow.ellipsis,
+                                )),
+                          }
+                        ]),
+                      }
                     ],
                   )),
             ],

--- a/lib/page/scholar/course_list/course_brief_card.dart
+++ b/lib/page/scholar/course_list/course_brief_card.dart
@@ -55,7 +55,11 @@ class CourseBriefCard extends StatelessWidget {
                               ),
                             ),
                           ),
-                          Text('  ${course.credit.toStringAsFixed(1)} 学分',
+                          // 显示学分，如果没有则显示"学分未知"
+                          Text(
+                              course.credit > 0 
+                                  ? '  ${course.credit.toStringAsFixed(1)} 学分'
+                                  : '  学分未知',
                               style: CupertinoTheme.of(context)
                                   .textTheme
                                   .textStyle


### PR DESCRIPTION
## 相关问题
- 本科生选研究生：#65 #68
- 研究生选本科生：#47 #75
- 课程详情页面无法打开： #74
- 研究生课程类型和学分信息的抓取 #98

## 进度

- [x] 本科生网研究生课程忽略
- [x] 研究生网忽略本科生课程/具体处理
- [x] 研究生用新的url抓取课程类型和课程学分
- [x] 平台测试
  - [x] iOS 18.5 iPhone15 虚拟机
  - [x] Harmony 4.2.0 nova12 实机
  - [x] Harmony4.2.0.183 HUAWEI P6O 实机
- [x] chore 尽可能小改动数据结构

- [x] 账号类型测试
  - [x] 本科生选修研究生课


## 具体排查

### 问题1 本科生选研究生

未抓到考试信息；未抓到学分信息也应该可以加载

把研究生抓取部分注释掉以后，依然有bug，所以应该是本科生课程抓取部分有问题，找到cele抓本科生课表的url 是这个 `https://zdbk.zju.edu.cn/jwglxt/kbcx/xskbcx_cxXsKb.html`，即教务网的课表功能

看了一下应该是实现了同步研究生课程的功能，比如我自己的课表

<img width="1080" height="854" alt="Image" src="https://github.com/user-attachments/assets/9a3f9a35-898b-42e4-9e94-68d147418870" />

但是抓了一下返回的json数据，对应的研究生课程是没有`xkkh`(选课课号？) 这一关键参数的，可能会导致解析会有问题

而对应的本科生课是有这一参数的
```
"xkkh": "(2025-2026-1)-CSE4070M-0091102-1"
```

研究生多加了一个字段`sfyjskc`(是否研究生课程？)
把带有这个字段的课程忽略，就不会报`LateInitializationError`了，需要修改2行代码

cele目前的解析逻辑是

- 对于本科生：本科课程在本科教务网抓取，研究生课程在研究生网抓取；
- 对于研究生： vice versa

但是教务网后端已经实现了双向同步的功能
所以不仅是本科生选研究生课会遇到这个问题，研究生选本科课同样也会遇到 #75 

所以后续可能需要优化一下这个问题，或者增加一些合并抓取课程的代码

- [x] 本科生登录研究生平台会同步本科课程吗： 不会
- [x] 本科生登录本科生平台会同步研究生课程吗：会的
- [x] 研究生登录研究生平台会同步本科课程吗：不会
- [x] 研究生登录本科生平台会同步研究生课程吗：暂时没有相关样本，留后续 PR 解决

最小修复方案就是忽略这些同步在另一平台的课程

### 问题2  研究生课程的抓取问题

现有的抓取框架：

学分信息是依赖考试信息抓取，而有一些课程是没有考试的，这就会导致没有考试的课程无法更新，顺便带来详情信息卡

所以查看了一下研究生教务网，在我的课程界面有当学期所选课程，有学分等信息，但是不能选择其他学期的课程，不利于多学期更新

所以使用了查询全校开课情况这个页面的查询接口，查询补全了学分和上课方式、课程类型等


`_fetchCourseDetails` : 根据课程列表 sessions，通过研究生教务系统课程详情 API 补全每门课程的学分、上课方式（线上/线下）、课程类型等详细信息。


## 测试页面



### iOS 18.5 iPhone15 虚拟机
增加功能前我的解析课表

增加功能后我的课表，学分解析正常

<img width="362" height="253" alt="image" src="https://github.com/user-attachments/assets/a3adfead-be72-4163-8c5b-baee663407d8" />


课程标签

<img width="382" height="590" alt="image" src="https://github.com/user-attachments/assets/88c0c825-264e-40ac-afb6-3713c17c0997" />
<img width="382" height="590" alt="image" src="https://github.com/user-attachments/assets/a1953e22-b2e2-4352-a585-799f4ffc066e" />

### Harmony 4.2.0 nova12

<img width="424" height="290" alt="image" src="https://github.com/user-attachments/assets/707e3ac8-efe5-4a64-a7b5-7a6dd75ea1b6" />

<img width="429" height="594" alt="image" src="https://github.com/user-attachments/assets/c0942614-225b-44af-ad7f-5f66b9ec4451" />

<img width="575" height="1279" alt="image" src="https://github.com/user-attachments/assets/c76b3371-86a1-4645-a885-c3e6d2b4176f" />
<img width="720" height="1602" alt="image" src="https://github.com/user-attachments/assets/ee04fe09-9b79-4770-a947-6607a230886d" />

### Harmony4.2.0.183 HUAWEI P6O 实机
![401665819592f7e920d044ac41803373](https://github.com/user-attachments/assets/de37d120-a31f-46e8-a313-4668efac690b)

![3bec506c47259eafb0dc290887f6f846](https://github.com/user-attachments/assets/e801158e-935d-44c4-bfab-b652c6cb6e40)
