### PR TITLE
feat: 增加付款码刷新按钮

### DIFF
--- a/lib/page/option/ecard_pay_page.dart
+++ b/lib/page/option/ecard_pay_page.dart
@@ -105,6 +105,48 @@ class ECardPayPage extends StatelessWidget {
                   return Text(
                       '付款码：${_barcode.value.isNotEmpty ? _barcode.value : '加载失败'}');
                 }),
+                const SizedBox(
+                  height: 30,
+                ),
+                Obx(() {
+                  if (_loading.value) {
+                    return const SizedBox.shrink();
+                  }
+                  return CupertinoButton(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 24,
+                      vertical: 12,
+                    ),
+                    color: CupertinoColors.activeBlue,
+                    borderRadius: BorderRadius.circular(20),
+                    onPressed: () {
+                      _loading.value = true;
+                      _requestNewCode().then((value) {
+                        _loading.value = false;
+                        _barcode.value = value ?? '';
+                      });
+                    },
+                    child: const Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          CupertinoIcons.refresh,
+                          size: 18,
+                          color: CupertinoColors.white,
+                        ),
+                        SizedBox(width: 8),
+                        Text(
+                          '刷新二维码',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w500,
+                            color: CupertinoColors.white,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                }),
                 const Spacer(
                   flex: 6,
                 ),


### PR DESCRIPTION
完成 #102 提到的功能

有关issue #102 #79 #67 

在iOS 18.5 iPhone15上虚拟机上进行了测试

<img width="336" height="260" alt="image" src="https://github.com/user-attachments/assets/f9614282-f6d6-4849-b8ff-2eb2b281ba11" />

<img width="328" height="278" alt="image" src="https://github.com/user-attachments/assets/6af8035c-2465-4196-96c3-23ba7270ab35" />


付款码加载失败的时候，相对位置准确

<img width="371" height="755" alt="image" src="https://github.com/user-attachments/assets/0897e099-61a2-45f4-bdf5-f7d2bfce54c7" />
