### PR TITLE
UI: 期中考试相关显示

### DIFF
--- a/lib/page/scholar/course_detail/course_detail_view.dart
+++ b/lib/page/scholar/course_detail/course_detail_view.dart
@@ -182,9 +182,11 @@ class CourseDetailPage extends StatelessWidget {
                             Container(
                               width: 12.0,
                               height: 12.0,
-                              decoration: const BoxDecoration(
+                              decoration: BoxDecoration(
                                 color: CupertinoColors.systemPink,
-                                shape: BoxShape.rectangle,
+                                shape: exams[0].type == ExamType.midterm
+                                    ? BoxShape.circle
+                                    : BoxShape.rectangle,
                               ),
                             ),
                             const SizedBox(width: 8.0),
@@ -247,6 +249,30 @@ class CourseDetailPage extends StatelessWidget {
                                     overflow: TextOverflow.ellipsis,
                                   )))
                         ]),
+                        if (exams[0].type == ExamType.midterm)
+                          Row(children: [
+                            Icon(
+                              CupertinoIcons.doc_text,
+                              size: 14,
+                              color: CupertinoTheme.of(context)
+                                  .textTheme
+                                  .textStyle
+                                  .color!
+                                  .withValues(alpha: 0.5),
+                            ),
+                            Expanded(
+                                child: Text(' 类型：期中',
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.normal,
+                                      color: CupertinoTheme.of(context)
+                                          .textTheme
+                                          .textStyle
+                                          .color!
+                                          .withValues(alpha: 0.75),
+                                      overflow: TextOverflow.ellipsis,
+                                    )))
+                          ]),
                       ],
                     ),
                     for (var i = 1; i < exams.length; i++)
@@ -265,9 +291,11 @@ class CourseDetailPage extends StatelessWidget {
                               Container(
                                 width: 12.0,
                                 height: 12.0,
-                                decoration: const BoxDecoration(
+                                decoration: BoxDecoration(
                                   color: CupertinoColors.systemPink,
-                                  shape: BoxShape.rectangle,
+                                  shape: exams[i].type == ExamType.midterm
+                                      ? BoxShape.circle
+                                      : BoxShape.rectangle,
                                 ),
                               ),
                               const SizedBox(width: 8.0),
@@ -330,6 +358,30 @@ class CourseDetailPage extends StatelessWidget {
                                       overflow: TextOverflow.ellipsis,
                                     )))
                           ]),
+                          if (exams[i].type == ExamType.midterm)
+                            Row(children: [
+                              Icon(
+                                CupertinoIcons.doc_text,
+                                size: 14,
+                                color: CupertinoTheme.of(context)
+                                    .textTheme
+                                    .textStyle
+                                    .color!
+                                    .withValues(alpha: 0.5),
+                              ),
+                              Expanded(
+                                  child: Text(' 类型：期中',
+                                      style: TextStyle(
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.normal,
+                                        color: CupertinoTheme.of(context)
+                                            .textTheme
+                                            .textStyle
+                                            .color!
+                                            .withValues(alpha: 0.75),
+                                        overflow: TextOverflow.ellipsis,
+                                      )))
+                            ]),
                         ],
                       ),
                   ],

--- a/lib/page/scholar/exam_list/exam_list_view.dart
+++ b/lib/page/scholar/exam_list/exam_list_view.dart
@@ -39,14 +39,17 @@ class ExamListPage extends StatelessWidget {
                           Container(
                             width: 12.0,
                             height: 12.0,
-                            decoration: const BoxDecoration(
+                            decoration: BoxDecoration(
                               color: CupertinoColors.systemPink,
-                              shape: BoxShape.rectangle,
+                              shape: exams[0].type == ExamType.midterm
+                                  ? BoxShape.circle
+                                  : BoxShape.rectangle,
                             ),
                           ),
                           const SizedBox(width: 8.0),
                           Expanded(
-                              child: Text(exams[0].name,
+                              child: Text(
+                                  '${exams[0].name}${exams[0].type == ExamType.midterm ? "（期中）" : ""}',
                                   style: CupertinoTheme.of(context)
                                       .textTheme
                                       .textStyle
@@ -145,14 +148,17 @@ class ExamListPage extends StatelessWidget {
                             Container(
                               width: 12.0,
                               height: 12.0,
-                              decoration: const BoxDecoration(
+                              decoration: BoxDecoration(
                                 color: CupertinoColors.systemPink,
-                                shape: BoxShape.rectangle,
+                                shape: exams[i].type == ExamType.midterm
+                                    ? BoxShape.circle
+                                    : BoxShape.rectangle,
                               ),
                             ),
                             const SizedBox(width: 8.0),
                             Expanded(
-                                child: Text(exams[i].name,
+                                child: Text(
+                                    '${exams[i].name}${exams[i].type == ExamType.midterm ? "（期中）" : ""}',
                                     style: CupertinoTheme.of(context)
                                         .textTheme
                                         .textStyle


### PR DESCRIPTION
## 内容

- [x] 在考试详情界面增加期中考试表述
- [x] 在课程详情界面增加期中考试表述
- [x] 在两个界面把期中考试 shape 改为 circle 以作区分

## 测试
- [x] 在iPhone虚拟机和实机(16pro)上做了测试

不涉及抓取逻辑更改

- 课程详情界面
![IMG_4540](https://github.com/user-attachments/assets/f09923a0-b515-426d-b031-c304b505eb60)

- 考试详情界面
![IMG_4539](https://github.com/user-attachments/assets/34e46708-f34c-445e-aa22-29d141ec9b69)
