### PR TITLE
UI: 日程界面增加课表入口，并修复因课名太长或冲突太多而导致的overflow

### DIFF
--- a/lib/page/calendar/calendar_controller.dart
+++ b/lib/page/calendar/calendar_controller.dart
@@ -4,6 +4,12 @@ import 'package:get/get.dart';
 import 'package:table_calendar/table_calendar.dart';
 import 'package:celechron/model/period.dart';
 import 'package:celechron/model/scholar.dart';
+import 'package:celechron/model/semester.dart';
+
+enum CalendarViewMode {
+  calendar,
+  schedule,
+}
 
 class CalendarController extends GetxController {
   final selectedDay = DateTime.now().obs;
@@ -12,6 +18,7 @@ class CalendarController extends GetxController {
   final events = <DateTime, List<Period>>{}.obs;
   final scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
   final taskList = Get.find<RxList<Task>>(tag: 'taskList');
+  final viewMode = CalendarViewMode.calendar.obs;
 
   static List<String> numToChinese = ['一', '二', '三', '四', '五', '六', '七', '八'];
 
@@ -75,5 +82,34 @@ class CalendarController extends GetxController {
     }
     eventsOfDay.sort((a, b) => a.startTime.compareTo(b.startTime));
     return eventsOfDay;
+  }
+
+  void toggleViewMode() {
+    viewMode.value = viewMode.value == CalendarViewMode.calendar
+        ? CalendarViewMode.schedule
+        : CalendarViewMode.calendar;
+  }
+
+  Semester? getCurrentSemester() {
+    final now = DateTime.now();
+    return scholar.value.semesters.firstWhereOrNull(
+      (e) => !now.isBefore(e.firstDay) && !now.isAfter(e.lastDay),
+    );
+  }
+
+  bool isFirstHalfSemester(Semester semester) {
+    final now = DateTime.now();
+    final toFirstWeek = now.difference(semester.firstDay).inDays ~/ 7;
+    return toFirstWeek < 8;
+  }
+
+  String getCurrentSemesterDisplayName() {
+    final semester = getCurrentSemester();
+    if (semester == null) return '无学期信息';
+    
+    final isFirstHalf = isFirstHalfSemester(semester);
+    final semesterName = '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}';
+    final halfName = isFirstHalf ? semester.firstHalfName : semester.secondHalfName;
+    return '$semesterName $halfName学期';
   }
 }

--- a/lib/page/calendar/calendar_controller.dart
+++ b/lib/page/calendar/calendar_controller.dart
@@ -106,10 +106,12 @@ class CalendarController extends GetxController {
   String getCurrentSemesterDisplayName() {
     final semester = getCurrentSemester();
     if (semester == null) return '无学期信息';
-    
+
     final isFirstHalf = isFirstHalfSemester(semester);
-    final semesterName = '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}';
-    final halfName = isFirstHalf ? semester.firstHalfName : semester.secondHalfName;
+    final semesterName =
+        '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}';
+    final halfName =
+        isFirstHalf ? semester.firstHalfName : semester.secondHalfName;
     return '$semesterName $halfName学期';
   }
 }

--- a/lib/page/calendar/calendar_view.dart
+++ b/lib/page/calendar/calendar_view.dart
@@ -69,7 +69,8 @@ class CalendarPage extends StatelessWidget {
                                     CupertinoColors.systemBlue, context))),
                         onPressed: () {
                           _calendarController.focusedDay.value = DateTime.now();
-                          _calendarController.selectedDay.value = DateTime.now();
+                          _calendarController.selectedDay.value =
+                              DateTime.now();
                         },
                       ),
                     ],
@@ -101,127 +102,136 @@ class CalendarPage extends StatelessWidget {
                   return Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 5, left: 12, right: 12),
-                      child: TableCalendar(
-                  locale: 'zh_CN',
-                  firstDay: DateTime.utc(2022, 9, 1),
-                  lastDay: DateTime.utc(2030, 12, 31),
-                  rowHeight: 48.0,
-                  daysOfWeekHeight: 20.0,
-                  startingDayOfWeek: StartingDayOfWeek.monday,
-                  daysOfWeekStyle: DaysOfWeekStyle(
-                    dowTextFormatter: (date, locale) => <String>[
-                      '',
-                      '一',
-                      '二',
-                      '三',
-                      '四',
-                      '五',
-                      '六',
-                      '日'
-                    ][date.weekday],
-                  ),
-                  availableGestures: AvailableGestures.all,
-                  availableCalendarFormats: const {
-                    CalendarFormat.month: '显示整月',
-                    CalendarFormat.week: '显示一周',
-                  },
-                  headerVisible: false,
-                  focusedDay: _calendarController.focusedDay.value,
-                  selectedDayPredicate: (day) {
-                    return isSameDay(
-                        _calendarController.selectedDay.value, day);
-                  },
-                  calendarFormat: _calendarController.calendarFormat.value,
-                  onPageChanged: (focusedDay) {
-                    _calendarController.focusedDay.value = focusedDay;
-                  },
-                  onDaySelected: (selectedDay, focusedDay) {
-                    _calendarController.focusedDay.value = focusedDay;
-                    _calendarController.selectedDay.value = selectedDay;
-                    _calendarController.focusedDay.refresh();
-                  },
-                  onFormatChanged: (format) {
-                    _calendarController.calendarFormat.value = format;
-                  },
-                  eventLoader: (day) {
-                    return _calendarController.getEventsForDay(day);
-                  },
-                  calendarStyle: CalendarStyle(
-                    markersAnchor: -0.1,
-                    markersMaxCount: 10,
-                    selectedDecoration: BoxDecoration(
-                      color: CupertinoDynamicColor.resolve(
-                          CupertinoColors.activeBlue.withValues(alpha: 0.5),
-                          context),
-                      shape: BoxShape.circle,
-                    ),
-                    selectedTextStyle:
-                        CupertinoTheme.of(context).textTheme.textStyle,
-                    todayDecoration: BoxDecoration(
-                      color: CupertinoDynamicColor.resolve(
-                          CupertinoColors.inactiveGray.withValues(alpha: 0.5),
-                          context),
-                      shape: BoxShape.circle,
-                    ),
-                    todayTextStyle:
-                        CupertinoTheme.of(context).textTheme.textStyle,
-                    defaultTextStyle:
-                        CupertinoTheme.of(context).textTheme.textStyle,
-                  ),
-                        calendarBuilders: const CalendarBuilders(
-                          singleMarkerBuilder: singleMarkerBuilder,
+                      Padding(
+                        padding: const EdgeInsets.only(
+                            bottom: 5, left: 12, right: 12),
+                        child: TableCalendar(
+                          locale: 'zh_CN',
+                          firstDay: DateTime.utc(2022, 9, 1),
+                          lastDay: DateTime.utc(2030, 12, 31),
+                          rowHeight: 48.0,
+                          daysOfWeekHeight: 20.0,
+                          startingDayOfWeek: StartingDayOfWeek.monday,
+                          daysOfWeekStyle: DaysOfWeekStyle(
+                            dowTextFormatter: (date, locale) => <String>[
+                              '',
+                              '一',
+                              '二',
+                              '三',
+                              '四',
+                              '五',
+                              '六',
+                              '日'
+                            ][date.weekday],
+                          ),
+                          availableGestures: AvailableGestures.all,
+                          availableCalendarFormats: const {
+                            CalendarFormat.month: '显示整月',
+                            CalendarFormat.week: '显示一周',
+                          },
+                          headerVisible: false,
+                          focusedDay: _calendarController.focusedDay.value,
+                          selectedDayPredicate: (day) {
+                            return isSameDay(
+                                _calendarController.selectedDay.value, day);
+                          },
+                          calendarFormat:
+                              _calendarController.calendarFormat.value,
+                          onPageChanged: (focusedDay) {
+                            _calendarController.focusedDay.value = focusedDay;
+                          },
+                          onDaySelected: (selectedDay, focusedDay) {
+                            _calendarController.focusedDay.value = focusedDay;
+                            _calendarController.selectedDay.value = selectedDay;
+                            _calendarController.focusedDay.refresh();
+                          },
+                          onFormatChanged: (format) {
+                            _calendarController.calendarFormat.value = format;
+                          },
+                          eventLoader: (day) {
+                            return _calendarController.getEventsForDay(day);
+                          },
+                          calendarStyle: CalendarStyle(
+                            markersAnchor: -0.1,
+                            markersMaxCount: 10,
+                            selectedDecoration: BoxDecoration(
+                              color: CupertinoDynamicColor.resolve(
+                                  CupertinoColors.activeBlue
+                                      .withValues(alpha: 0.5),
+                                  context),
+                              shape: BoxShape.circle,
+                            ),
+                            selectedTextStyle:
+                                CupertinoTheme.of(context).textTheme.textStyle,
+                            todayDecoration: BoxDecoration(
+                              color: CupertinoDynamicColor.resolve(
+                                  CupertinoColors.inactiveGray
+                                      .withValues(alpha: 0.5),
+                                  context),
+                              shape: BoxShape.circle,
+                            ),
+                            todayTextStyle:
+                                CupertinoTheme.of(context).textTheme.textStyle,
+                            defaultTextStyle:
+                                CupertinoTheme.of(context).textTheme.textStyle,
+                          ),
+                          calendarBuilders: const CalendarBuilders(
+                            singleMarkerBuilder: singleMarkerBuilder,
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(height: 16),
-                    Obx(
-                      () => SubSubtitleRow(
-                          padHorizontal: 24,
-                          subtitle: _calendarController.dayDescription(
-                              _calendarController.selectedDay.value
-                                  .copyWith(isUtc: false)),
-                          right: _calendarController.scholar.value.specialDates
-                                  .containsKey(_calendarController.selectedDay.value
-                                      .copyWith(isUtc: false))
-                              ? Container(
-                                  padding: const EdgeInsets.symmetric(
-                                      horizontal: 8, vertical: 4),
-                                  decoration: BoxDecoration(
-                                      border: Border.all(
+                      const SizedBox(height: 16),
+                      Obx(
+                        () => SubSubtitleRow(
+                            padHorizontal: 24,
+                            subtitle: _calendarController.dayDescription(
+                                _calendarController.selectedDay.value
+                                    .copyWith(isUtc: false)),
+                            right: _calendarController
+                                    .scholar.value.specialDates
+                                    .containsKey(_calendarController
+                                        .selectedDay.value
+                                        .copyWith(isUtc: false))
+                                ? Container(
+                                    padding: const EdgeInsets.symmetric(
+                                        horizontal: 8, vertical: 4),
+                                    decoration: BoxDecoration(
+                                        border: Border.all(
+                                            color: CustomCupertinoDynamicColors
+                                                .okGreen.darkColor,
+                                            width: 1),
+                                        borderRadius:
+                                            BorderRadius.circular(10)),
+                                    child: Text(
+                                      _calendarController
+                                              .scholar.value.specialDates[
+                                          _calendarController.selectedDay.value
+                                              .copyWith(isUtc: false)]!,
+                                      style: TextStyle(
                                           color: CustomCupertinoDynamicColors
                                               .okGreen.darkColor,
-                                          width: 1),
-                                      borderRadius: BorderRadius.circular(10)),
-                                  child: Text(
-                                    _calendarController.scholar.value.specialDates[
-                                        _calendarController.selectedDay.value
-                                            .copyWith(isUtc: false)]!,
-                                    style: TextStyle(
-                                        color: CustomCupertinoDynamicColors
-                                            .okGreen.darkColor,
-                                        fontSize: 12),
+                                          fontSize: 12),
+                                    ),
+                                  )
+                                : null),
+                      ),
+                      Expanded(
+                        child: Obx(
+                          () => ListView(
+                            children: _calendarController
+                                .getEventsForDay(
+                                    _calendarController.selectedDay.value)
+                                .map(
+                                  (e) => Padding(
+                                    padding: const EdgeInsets.symmetric(
+                                        vertical: 5, horizontal: 16),
+                                    child: createCard(context, e),
                                   ),
                                 )
-                              : null),
-                    ),
-                    Expanded(
-                      child: Obx(
-                        () => ListView(
-                          children: _calendarController
-                              .getEventsForDay(_calendarController.selectedDay.value)
-                              .map(
-                                (e) => Padding(
-                                  padding: const EdgeInsets.symmetric(
-                                      vertical: 5, horizontal: 16),
-                                  child: createCard(context, e),
-                                ),
-                              )
-                              .toList(),
+                                .toList(),
+                          ),
                         ),
                       ),
-                    ),
                     ],
                   );
                 },

--- a/lib/page/calendar/schedule_view.dart
+++ b/lib/page/calendar/schedule_view.dart
@@ -1,0 +1,322 @@
+import 'dart:math';
+
+import 'package:celechron/utils/tuple.dart';
+import 'package:celechron/model/session.dart';
+import 'package:celechron/design/round_rectangle_card.dart';
+import 'package:celechron/page/scholar/course_schedule/course_card.dart';
+import 'package:celechron/page/calendar/calendar_controller.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+class ScheduleView extends StatelessWidget {
+  final CalendarController controller;
+
+  const ScheduleView({super.key, required this.controller});
+
+  Widget _courseSchedule(BuildContext context) {
+    const List<String> courseStartTime = [
+      "08:00",
+      "08:50",
+      "10:00",
+      "10:50",
+      "11:40",
+      "13:25",
+      "14:15",
+      "15:05",
+      "16:15",
+      "17:05",
+      "18:50",
+      "19:40",
+      "20:30"
+    ];
+    return RoundRectangleCard(
+      child: Column(
+        children: [
+          Row(
+            children: [
+              const Spacer(flex: 1),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '一',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '二',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '三',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '四',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '五',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '六',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Center(
+                  child: Text(
+                    '日',
+                    style:
+                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                              fontSize: 14,
+                            ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          SizedBox(
+            height: 560,
+            child: Obx(
+              () {
+                final semester = controller.getCurrentSemester();
+                if (semester == null) {
+                  return Center(
+                    child: Text(
+                      '当前不在学期内',
+                      style: CupertinoTheme.of(context)
+                          .textTheme
+                          .textStyle
+                          .copyWith(fontSize: 16),
+                    ),
+                  );
+                }
+
+                final isFirstHalf = controller.isFirstHalfSemester(semester);
+                final sessionsByDayOfWeek = isFirstHalf
+                    ? semester.firstHalfTimetable
+                    : semester.secondHalfTimetable;
+
+                return Row(
+                  children: [
+                    Expanded(
+                      flex: 1,
+                      child: Column(
+                        children: [
+                          for (var i = 1; i <= 13; i++)
+                            Expanded(
+                              child: Center(
+                                child: Column(
+                                  children: [
+                                    FittedBox(
+                                      fit: BoxFit.fitWidth,
+                                      child: Text(
+                                        courseStartTime[i - 1],
+                                        style: CupertinoTheme.of(context)
+                                            .textTheme
+                                            .textStyle
+                                            .copyWith(
+                                              fontSize: 10,
+                                            ),
+                                      ),
+                                    ),
+                                    const SizedBox(
+                                      height: 2,
+                                    ),
+                                    Text(
+                                      i.toString(),
+                                      style: CupertinoTheme.of(context)
+                                          .textTheme
+                                          .textStyle
+                                          .copyWith(
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: 14,
+                                          ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    for (var i = 1; i <= 6; i++)
+                      Expanded(
+                        flex: 2,
+                        child: LayoutBuilder(
+                          builder: (context, constraints) => Stack(
+                            children: [
+                              Column(
+                                children: [
+                                  for (var j = 1; j <= 12; j++)
+                                    Expanded(
+                                      child: Container(),
+                                    ),
+                                  Expanded(
+                                    child: Container(),
+                                  ),
+                                ],
+                              ),
+                              ..._buildCourseScheduleByDayOfWeek(
+                                  sessionsByDayOfWeek, i, constraints)
+                            ],
+                          ),
+                        ),
+                      ),
+                    Expanded(
+                      flex: 2,
+                      child: LayoutBuilder(
+                        builder: (context, constraints) => Stack(
+                          children: [
+                            Column(
+                              children: [
+                                for (var j = 1; j <= 12; j++)
+                                  Expanded(
+                                    child: Container(),
+                                  ),
+                                Expanded(child: Container())
+                              ],
+                            ),
+                            ..._buildCourseScheduleByDayOfWeek(
+                                sessionsByDayOfWeek, 7, constraints)
+                          ],
+                        ),
+                      ),
+                    )
+                  ],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildCourseScheduleByDayOfWeek(
+      List<List<Session>> sessionsByDayOfWeek,
+      int day,
+      BoxConstraints constraints) {
+    List<Tuple<int, int>> period = [];
+    for (var i = 1; i <= 13; i++) {
+      period.add(Tuple(i, i));
+    }
+    for (var s in sessionsByDayOfWeek[day]) {
+      int sl = s.time.first, sr = s.time.last;
+      int xl = sl, xr = sr;
+      for (var i in period) {
+        if (!(i.item2 < sl || sr < i.item1)) {
+          xl = min(xl, i.item1);
+          xr = max(xr, i.item2);
+        }
+      }
+      period.removeWhere((x) => xl <= x.item1 && x.item2 <= xr);
+      period.add(Tuple(xl, xr));
+    }
+    List<List<Session>> sessionList = [];
+    for (var _ in period) {
+      sessionList.add([]);
+    }
+    for (var s in sessionsByDayOfWeek[day]) {
+      int sl = s.time.first, sr = s.time.last;
+      for (int i = 0; i < period.length; i++) {
+        if (!(period[i].item2 < sl || sr < period[i].item1)) {
+          bool added = false;
+          for (var t in sessionList[i]) {
+            if (t.id == s.id) {
+              added = true;
+              Set<int> timeSet = Set.from(t.time);
+              timeSet.addAll(s.time);
+              t.time = List.from(timeSet);
+              t.time.sort();
+              break;
+            }
+          }
+          if (!added) {
+            sessionList[i].add(Session.fromJson(s.toJson()));
+          }
+        }
+      }
+    }
+
+    List<Widget> cardList = [];
+    for (int i = 0; i < period.length; i++) {
+      if (sessionList[i].isNotEmpty) {
+        cardList.add(
+          Positioned.fromRelativeRect(
+            rect: RelativeRect.fromLTRB(
+              0,
+              (period[i].item1 - 1) * constraints.maxHeight / 13,
+              0,
+              (13 - period[i].item2) * constraints.maxHeight / 13,
+            ),
+            child: SessionCard(
+              sessionList: sessionList[i],
+              hideInfomation: false,
+            ),
+          ),
+        );
+      }
+    }
+
+    return cardList;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        child: _courseSchedule(context),
+      ),
+    );
+  }
+}
+

--- a/lib/page/calendar/schedule_view.dart
+++ b/lib/page/calendar/schedule_view.dart
@@ -319,4 +319,3 @@ class ScheduleView extends StatelessWidget {
     );
   }
 }
-

--- a/lib/page/scholar/course_schedule/course_card.dart
+++ b/lib/page/scholar/course_schedule/course_card.dart
@@ -152,43 +152,57 @@ class _SessionCardState extends State<SessionCard>
             right: 1.4,
           ),
           child: Container(
-            alignment: Alignment.center,
+            alignment: Alignment.topCenter,
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(4),
               color: CupertinoDynamicColor.resolve(
                   widget.backgroundColor, context),
             ),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.start,
-              children: [
-                const SizedBox(height: 4),
-                Text(
-                  sessionName,
-                  textAlign: TextAlign.center,
-                  maxLines: widget.sessionList.length * 5,
-                  overflow: TextOverflow.ellipsis,
-                  style:
-                      CupertinoTheme.of(context).textTheme.textStyle.copyWith(
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
-                            color: const Color.fromRGBO(255, 255, 255, 1.0),
-                          ),
+            child: ClipRect(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 2.0, right: 2.0, top: 2.0, bottom: 2.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    Flexible(
+                      fit: FlexFit.loose,
+                      child: Text(
+                        sessionName,
+                        textAlign: TextAlign.center,
+                        maxLines: widget.sessionList.length == 1 
+                            ? 3  // 单课程最多3行
+                            : (widget.sessionList.length * 2).clamp(2, 6), // 冲突课程最多6行
+                        overflow: TextOverflow.ellipsis,
+                        style:
+                            CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                  color: const Color.fromRGBO(255, 255, 255, 1.0),
+                                ),
+                      ),
+                    ),
+                    if (!widget.hideInfomation && sessionLocation.isNotEmpty) ...[
+                      const SizedBox(height: 2),
+                      Flexible(
+                        fit: FlexFit.loose,
+                        child: Text(
+                          sessionLocation,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.center,
+                          style:
+                              CupertinoTheme.of(context).textTheme.textStyle.copyWith(
+                                    fontSize: 9,
+                                    color: const Color.fromRGBO(255, 255, 255, 0.9),
+                                  ),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-                const SizedBox(height: 8),
-                Flexible(
-                  child: Text(
-                    sessionLocation,
-                    maxLines: 4,
-                    overflow: TextOverflow.ellipsis,
-                    textAlign: TextAlign.center,
-                    style:
-                        CupertinoTheme.of(context).textTheme.textStyle.copyWith(
-                              fontSize: 10,
-                              color: const Color.fromRGBO(255, 255, 255, 1.0),
-                            ),
-                  ),
-                ),
-              ],
+              ),
             ),
           ),
         ),

--- a/lib/page/scholar/course_schedule/course_card.dart
+++ b/lib/page/scholar/course_schedule/course_card.dart
@@ -160,7 +160,8 @@ class _SessionCardState extends State<SessionCard>
             ),
             child: ClipRect(
               child: Padding(
-                padding: const EdgeInsets.only(left: 2.0, right: 2.0, top: 2.0, bottom: 2.0),
+                padding: const EdgeInsets.only(
+                    left: 2.0, right: 2.0, top: 2.0, bottom: 2.0),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
@@ -171,19 +172,23 @@ class _SessionCardState extends State<SessionCard>
                       child: Text(
                         sessionName,
                         textAlign: TextAlign.center,
-                        maxLines: widget.sessionList.length == 1 
-                            ? 3  // 单课程最多3行
-                            : (widget.sessionList.length * 2).clamp(2, 6), // 冲突课程最多6行
+                        maxLines: widget.sessionList.length == 1
+                            ? 3 // 单课程最多3行
+                            : (widget.sessionList.length * 2)
+                                .clamp(2, 6), // 冲突课程最多6行
                         overflow: TextOverflow.ellipsis,
-                        style:
-                            CupertinoTheme.of(context).textTheme.textStyle.copyWith(
-                                  fontSize: 10,
-                                  fontWeight: FontWeight.bold,
-                                  color: const Color.fromRGBO(255, 255, 255, 1.0),
-                                ),
+                        style: CupertinoTheme.of(context)
+                            .textTheme
+                            .textStyle
+                            .copyWith(
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                              color: const Color.fromRGBO(255, 255, 255, 1.0),
+                            ),
                       ),
                     ),
-                    if (!widget.hideInfomation && sessionLocation.isNotEmpty) ...[
+                    if (!widget.hideInfomation &&
+                        sessionLocation.isNotEmpty) ...[
                       const SizedBox(height: 2),
                       Flexible(
                         fit: FlexFit.loose,
@@ -192,11 +197,13 @@ class _SessionCardState extends State<SessionCard>
                           maxLines: 2,
                           overflow: TextOverflow.ellipsis,
                           textAlign: TextAlign.center,
-                          style:
-                              CupertinoTheme.of(context).textTheme.textStyle.copyWith(
-                                    fontSize: 9,
-                                    color: const Color.fromRGBO(255, 255, 255, 0.9),
-                                  ),
+                          style: CupertinoTheme.of(context)
+                              .textTheme
+                              .textStyle
+                              .copyWith(
+                                fontSize: 9,
+                                color: const Color.fromRGBO(255, 255, 255, 0.9),
+                              ),
                         ),
                       ),
                     ],


### PR DESCRIPTION
实现 #115 提到的功能

在日程界面中新增课表视图，用户可以通过右上角的图标按钮在日历视图和课表视图之间切换。课表视图显示当前学期的课程安排，左上角显示学期名称（包括前半/后半学期信息）

## 文件变更
- 复用了 `course_schedule_view.dart` 中的课表绘制逻辑
- 复用了 `course_card.dart` 中的 `SessionCard` 组件
### 新增文件
- `lib/page/calendar/schedule_view.dart`: 课表视图组件

### 修改文件
- `lib/page/calendar/calendar_controller.dart`: 添加视图状态管理和学期相关方法
- `lib/page/calendar/calendar_view.dart`: 添加视图切换功能和条件渲染


## 实现内容

### 1. 视图状态管理 (`lib/page/calendar/calendar_controller.dart`)

- 新增 `CalendarViewMode` 枚举类型，定义两种视图模式：
  - `calendar`: 日历视图（默认）
  - `schedule`: 课表视图

- 添加视图状态管理：
  - `viewMode`: 响应式变量，控制当前视图模式
  - `toggleViewMode()`: 切换视图模式的方法

- 添加学期相关方法：
  - `getCurrentSemester()`: 获取当前学期
  - `isFirstHalfSemester()`: 判断当前是前半学期还是后半学期
  - `getCurrentSemesterDisplayName()`: 获取学期显示名称（格式：`2024-2025 秋学期`）

### 2. 课表视图组件 (`lib/page/calendar/schedule_view.dart`)

- 创建新的课表视图组件，复用现有的课表绘制逻辑
- 显示当前学期的课表（根据当前日期自动判断前半/后半学期）
- 处理当前不在学期内的情况，显示友好提示
- 支持滚动查看完整课表

### 3. 日程界面更新 (`lib/page/calendar/calendar_view.dart`)

- 在右上角添加切换视图的图标按钮：
  - 日历视图模式下显示 `calendar` 图标
  - 课表视图模式下显示 `list_bullet` 图标
- 根据 `viewMode` 条件渲染不同的视图：
  - 日历视图：显示日历表格和任务列表
  - 课表视图：显示当前学期的课表
- 标题栏动态显示：
  - 日历视图：显示年月（如 `2024 年 12 月`）
  - 课表视图：显示学期名称（如 `2024-2025 秋学期`）
- 日历视图模式下保留原有的添加任务和"今天"按钮

## 测试平台

- [x] iOS 18.5 iPhone 15 虚拟机


## 截图
课表界面
<img width="381" height="693" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/1a677dd8-3b10-47fa-87dc-03b3bdd155cd" />
原先界面 右上角有icon用于切换
<img width="386" height="767" alt="2025年11月" src="https://github.com/user-attachments/assets/4b3cf1d1-3f41-4d91-8ed2-fcc5162b8c03" />




<img width="188" height="106" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/9d7bf8ee-0b11-4500-ba0c-a307114b0666" />

<img width="72" height="274" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/8132d360-dd7d-4947-bdd9-0d5b6a650eb4" />

<img width="188" height="106" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/9ff7b8ec-462a-45f9-b45c-524793b4587e" />
<img width="60" height="108" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/2e7a5f93-ba6a-4933-8c6f-5e7ab79f8fa4" />

