### PR TITLE
修复：仅在关闭弹窗后修改开始/结束时间

### DIFF
--- a/lib/page/task/task_edit_page.dart
+++ b/lib/page/task/task_edit_page.dart
@@ -218,16 +218,17 @@ class _TaskEditPageState extends State<TaskEditPage> {
                                       onDateTimeChanged: (DateTime newTime) {
                                         setState(() {
                                           now.startTime = newTime;
-                                          if (now.endTime
-                                              .isBefore(now.startTime)) {
-                                            now.endTime = now.startTime;
-                                          }
                                         });
                                       },
                                     ),
                                   ),
                                 );
                               });
+                          if (now.endTime.isBefore(now.startTime)) {
+                            setState(() {
+                              now.endTime = now.startTime;
+                            });
+                          }
                         },
                       ),
                     CupertinoTextFormFieldRow(
@@ -256,17 +257,18 @@ class _TaskEditPageState extends State<TaskEditPage> {
                                     onDateTimeChanged: (DateTime newTime) {
                                       setState(() {
                                         now.endTime = newTime;
-                                        if (now.type == TaskType.fixed &&
-                                            now.startTime
-                                                .isAfter(now.endTime)) {
-                                          now.startTime = now.endTime;
-                                        }
                                       });
                                     },
                                   ),
                                 ),
                               );
                             });
+                        if (now.type == TaskType.fixed &&
+                            now.startTime.isAfter(now.endTime)) {
+                          setState(() {
+                            now.startTime = now.endTime;
+                          });
+                        }
                       },
                     ),
                   ],


### PR DESCRIPTION
本合并请求修复了 #145 。
仅在用户关闭弹窗时，同步修改开始/结束时间，防止了在修改过程中 mess up 另一个时间。