### PR TITLE
feat: 离线缓存支持 - 刷新失败时保留已缓存的数据

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,9 @@ void main() async {
       GlobalStatus.isFirstScreenReq = true;
       await scholar.value.refresh();
       GlobalStatus.isFirstScreenReq = false;
+    }).catchError((e) {
+      // 离线或网络异常时不崩溃，保留缓存数据
+      GlobalStatus.isFirstScreenReq = false;
     }).then((value) => scholar.refresh());
   }
 

--- a/lib/model/scholar.dart
+++ b/lib/model/scholar.dart
@@ -240,9 +240,8 @@ class Scholar {
             aboardGpa = result.item1;
             // 所获学分，不包括挂科的。
             credit = result.item2;
-          } else {
-            credit = 0.0;
           }
+          // 无成绩数据时不重置学分，保留之前的缓存值
 
           await _db?.setScholar(this);
           return value.item1.every((e) => e == null)
@@ -301,20 +300,30 @@ class Scholar {
     if (tempSpecialDates.isNotEmpty) {
       specialDates = tempSpecialDates;
     }
-    if (errorResult[0] == false && tempGrades.isNotEmpty) {
+    // 无错误时更新数据；有错误但当前数据为空时，使用缓存数据作为回退
+    if (tempGrades.isNotEmpty &&
+        (errorResult[0] == false || grades.isEmpty)) {
       grades = tempGrades;
     }
-    if (errorResult[1] == false && tempMajorGpaAndCredit.isNotEmpty) {
+    if (tempMajorGpaAndCredit.isNotEmpty &&
+        (errorResult[1] == false ||
+            (majorGpaAndCredit[0] == 0.0 && majorGpaAndCredit[1] == 0.0))) {
       majorGpaAndCredit = tempMajorGpaAndCredit;
     }
-    if (errorResult[2] == false && tempSemesters.isNotEmpty) {
+    if (tempSemesters.isNotEmpty &&
+        (errorResult[2] == false || semesters.isEmpty)) {
       semesters = tempSemesters;
     }
-    if (errorResult[3] == false && tempTodos.isNotEmpty) {
+    if (tempTodos.isNotEmpty &&
+        (errorResult[3] == false || todos.isEmpty)) {
       todos = tempTodos;
     }
-    isPracticeScoresGet = tempIsPracticeScoresGet;
-    if (errorResult[4] == false && tempIsPracticeScoresGet) {
+    if (errorResult[4] == false) {
+      isPracticeScoresGet = tempIsPracticeScoresGet;
+    }
+    if (tempIsPracticeScoresGet &&
+        (errorResult[4] == false ||
+            (!isPracticeScoresGet && pt2 == 0.0 && pt3 == 0.0 && pt4 == 0.0))) {
       pt2 = tempPt2;
       pt3 = tempPt3;
       pt4 = tempPt4;


### PR DESCRIPTION
解决 Issues #129 和 #131：断网或翻墙状态下内容不再变空。

主要更改：
- GrsNew 服务增加缓存回退：研究生成绩、课表、考试数据在网络 请求失败时从本地缓存恢复，与本科生服务(zdbk/courses)保持一致
- Scholar.setScholar() 改进错误处理逻辑：当发生错误但当前数据 为空时，使用服务层返回的缓存数据作为回退，避免首次加载失败 后数据永远为空
- Scholar.refresh() 不再在无成绩数据时重置学分为0，保留缓存值
- main.dart 启动时增加 catchError 处理，防止离线启动崩溃

https://claude.ai/code/session_01AUkAs5wNy34U58LmqHrxyG