### PR TITLE
修复celechron成绩、课表等经常解析失败的bug

### DIFF
--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -113,6 +113,69 @@ class GrsSpider implements Spider {
     _grsNew.logout();
   }
 
+  // ===== 新增开始 =====
+  // 自动重试机制：遇到Cookie过期等错误时，自动重新登录再重试
+  Future<T> _fetchWithRetry<T>(Future<T> Function() operation,
+      {int maxRetries = 2}) async {
+    int attempts = 0;
+    while (true) {
+      try {
+        var result = await operation();
+
+        // 检查返回结果中是否隐藏了错误
+        bool hasHiddenError = false;
+        dynamic hiddenErrorToThrow;
+        try {
+          dynamic res = result;
+          if (res != null && res.item1 != null) {
+            String errStr = res.item1.toString().toLowerCase();
+            if (errStr.contains("connection closed") ||
+                errStr.contains("httpexception") ||
+                errStr.contains("网络错误") ||
+                errStr.contains("未登录") ||
+                errStr.contains("超时") ||
+                errStr.contains("timeout") ||
+                errStr.contains("type 'null'") ||
+                errStr.contains("iplanetdirectorypro无效") ||
+                errStr.contains("会话已过期")) {
+              hasHiddenError = true;
+              hiddenErrorToThrow = res.item1;
+            }
+          }
+        } catch (_) {}
+
+        if (hasHiddenError) {
+          throw hiddenErrorToThrow;
+        }
+
+        return result;
+      } catch (e) {
+        attempts++;
+        String errStr = e.toString().toLowerCase();
+
+        // 判断是否是可以通过重新登录解决的错误
+        if (attempts <= maxRetries &&
+            (e is SessionExpiredException ||
+                errStr.contains("未登录") ||
+                errStr.contains("iplanetdirectorypro无效") ||
+                errStr.contains("会话已过期") ||
+                errStr.contains("connection closed") ||
+                errStr.contains("timeout") ||
+                errStr.contains("超时") ||
+                errStr.contains("httpexception") ||
+                errStr.contains("网络错误") ||
+                errStr.contains("socketexception"))) {
+          await login(); // 重新获取 iPlanetDirectoryPro
+          await Future.delayed(const Duration(milliseconds: 1000));
+          continue;
+        }
+
+        rethrow;
+      }
+    }
+  }
+  // ===== 新增结束 =====
+
   // 返回一堆错误信息，如果有的话。看看返回的List是不是空的就知道刷新是否成功。
   @override
   Future<
@@ -231,7 +294,8 @@ class GrsSpider implements Spider {
           return Future.value("已取消");
         }
         try {
-          var value = await _zdbk.getTimetable(_httpClient, yearStr, season);
+          var value = await _fetchWithRetry(
+              () => _zdbk.getTimetable(_httpClient, yearStr, season));
           var semKey = season.startsWith('1') ? '$yearStr-1' : '$yearStr-2';
           var sessions = value.item2.toList();
           sessions.sort((a, b) {
@@ -328,7 +392,8 @@ class GrsSpider implements Spider {
         .then((value) => value.firstWhereOrNull((e) => e != null)));
 
     // 本科生课考试
-    fetches.add(_zdbk.getExamsDto(_httpClient).then((value) {
+    fetches.add(
+        _fetchWithRetry(() => _zdbk.getExamsDto(_httpClient)).then((value) {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addExam(e);
       }
@@ -336,7 +401,8 @@ class GrsSpider implements Spider {
     }).catchError((e) => 'zdbkExam $e'));
 
     // 查成绩
-    fetches.add(_zdbk.getTranscript(_httpClient).then((value) {
+    fetches.add(
+        _fetchWithRetry(() => _zdbk.getTranscript(_httpClient)).then((value) {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addGrade(e);
         outGrades.add(e);
@@ -349,7 +415,8 @@ class GrsSpider implements Spider {
         .then((value) => value.firstWhereOrNull((e) => e != null)));
 
     // 研究生课成绩
-    fetches.add(_grsNew.getGrade(_httpClient).then((value) {
+    fetches
+        .add(_fetchWithRetry(() => _grsNew.getGrade(_httpClient)).then((value) {
       for (var e in value.item2) {
         if (e.id.length < 6) {
           continue;
@@ -376,7 +443,8 @@ class GrsSpider implements Spider {
     }).catchError((e) => 'grsGrade $e'));
 
     // 学在浙大
-    fetches.add(_courses.getTodo(_httpClient).then((value) {
+    fetches
+        .add(_fetchWithRetry(() => _courses.getTodo(_httpClient)).then((value) {
       outTodos.clear();
       outTodos.addAll(value.item2);
       return value.item1?.toString();

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -29,7 +29,7 @@ class UgrsSpider implements Spider {
   Map<String, double>? _practiceScores;
   bool _isPracticeScoresGet = false;
 
-  Future<void>? _reloginFuture;
+  Future<List<String?>>? _reloginFuture;
 
   UgrsSpider(String username, String password) {
     _initHttpClient(); // 初始化客户端移到单独方法
@@ -61,14 +61,15 @@ class UgrsSpider implements Spider {
   @override
   Future<List<String?>> login() async {
     if (_reloginFuture != null) {
-      await _reloginFuture;
-      return [null];
+      return await _reloginFuture!;
     }
 
     _reloginFuture = _doLogin();
-    var result = await _reloginFuture;
-    _reloginFuture = null;
-    return result as List<String?>;
+    try {
+      return await _reloginFuture!;
+    } finally {
+      _reloginFuture = null;
+    }
   }
 
   Future<List<String?>> _doLogin() async {

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -186,7 +186,7 @@ class UgrsSpider implements Spider {
             errStr.contains("网络错误") ||
             errStr.contains("socketexception")
         )) {
-          print("⚡️⚡️ 第 $attempts 次自动修复：检测到异常(${e.toString()})，正在重试... ⚡️⚡️");
+          // print("第 $attempts 次自动修复：检测到异常(${e.toString()})，正在重试...");
           await login(); // 重建 HttpClient 并登录
           await Future.delayed(const Duration(milliseconds: 1000)); // 给服务器1秒缓冲
           continue; // 继续下一次尝试
@@ -328,7 +328,6 @@ class UgrsSpider implements Spider {
       }
 
 if (fetchGrs) {
-        // ... (保持原研究生逻辑，此处省略以节省篇幅，请保留你原文件中的逻辑)
         // 注意：如果原逻辑使用了 _httpClient，它会自动使用新的实例，因为是字段访问
         timetableFetches.add(
             _grsNew.getTimetable(_httpClient, yearEnroll, 13).then((value) {

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -12,15 +12,13 @@ import 'package:celechron/database/database_helper.dart';
 import 'package:celechron/model/grade.dart';
 import 'package:celechron/model/semester.dart';
 
-// import 'zjuServices/appservice.dart';
 import 'zjuServices/zjuam.dart';
 import 'zjuServices/zdbk.dart';
 
 class UgrsSpider implements Spider {
-  late HttpClient _httpClient;
+  late HttpClient _httpClient; // HTTP 客户端
   late String _username;
   late String _password;
-  // late AppService _appService;
   late Courses _courses;
   late Zdbk _zdbk;
   late GrsNew _grsNew;
@@ -29,13 +27,12 @@ class UgrsSpider implements Spider {
   DateTime _lastUpdateTime = DateTime(0);
   bool fetchGrs = false;
   Map<String, double>? _practiceScores;
-  bool _isPracticeScoresGet = false; // 是否成功获取到二三四课堂分数
+  bool _isPracticeScoresGet = false; 
+
+  Future<void>? _reloginFuture;
 
   UgrsSpider(String username, String password) {
-    _httpClient = HttpClient();
-    _httpClient.userAgent =
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.1587.63";
-    // _appService = AppService(db: _db);
+    _initHttpClient(); // 初始化客户端移到单独方法
     _courses = Courses();
     _zdbk = Zdbk();
     _grsNew = GrsNew();
@@ -44,9 +41,17 @@ class UgrsSpider implements Spider {
     _password = password;
   }
 
+  // 初始化或重置 HttpClient
+  void _initHttpClient() {
+    _httpClient = HttpClient();
+    _httpClient.userAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.1587.63";
+    // 强制不保存 Cookies，完全由 Zdbk 手动管理，避免冲突
+    // 同时也避免重定向时 HttpClient 自动携带旧 Cookie
+  }
+
   @override
   set db(DatabaseHelper? db) {
-    // _appService.db = db;
     _courses.db = db;
     _zdbk.db = db;
     _grsNew.db = db;
@@ -55,6 +60,24 @@ class UgrsSpider implements Spider {
 
   @override
   Future<List<String?>> login() async {
+    if (_reloginFuture != null) {
+      await _reloginFuture;
+      return [null];
+    }
+
+    _reloginFuture = _doLogin();
+    var result = await _reloginFuture;
+    _reloginFuture = null;
+    return result as List<String?>;
+  }
+
+  Future<List<String?>> _doLogin() async {
+    // 【关键修改】登录前先销毁旧的 HttpClient，防止旧 Cookie 或死连接干扰
+    try {
+      _httpClient.close(force: true);
+    } catch (_) {}
+    _initHttpClient(); // 创建全新的客户端
+
     var loginErrorMessages = <String?>[null];
     _iPlanetDirectoryPro =
         await ZjuAm.getSsoCookie(_httpClient, _username, _password)
@@ -65,14 +88,7 @@ class UgrsSpider implements Spider {
     });
     if (_iPlanetDirectoryPro == null) return loginErrorMessages;
     loginErrorMessages.addAll(await Future.wait(
-        // 本科生需要登录钉钉工作台、教务网、研究生院网（为了看研究生课）
         [
-          /*_appService
-              .login(_httpClient, _iPlanetDirectoryPro)
-              // ignore: unnecessary_cast
-              .then((value) => null as String?)
-              .timeout(const Duration(seconds: 8))
-              .catchError((e) => "无法登录钉钉工作台，$e"),*/
           _courses
               .login(_httpClient, _iPlanetDirectoryPro)
               // ignore: unnecessary_cast
@@ -93,8 +109,6 @@ class UgrsSpider implements Spider {
                 return null as String?;
               })
               .timeout(const Duration(seconds: 8))
-              // 本科生一般不需要登录研究生院，所以不管登录成功与否都不会报错
-              // ignore: unnecessary_cast
               .catchError((e) => null as String?),
         ]).then((value) {
       if (value.every((e) => e == null)) _lastUpdateTime = DateTime.now();
@@ -108,7 +122,6 @@ class UgrsSpider implements Spider {
     _username = "";
     _password = "";
     _iPlanetDirectoryPro = null;
-    // _appService.logout();
     _zdbk.logout();
     _grsNew.logout();
     _practiceScores = null;
@@ -118,7 +131,32 @@ class UgrsSpider implements Spider {
   Map<String, double>? get practiceScores => _practiceScores;
   bool get isPracticeScoresGet => _isPracticeScoresGet;
 
-  // 返回一堆错误信息，如果有的话。看看返回的List是不是空的就知道刷新是否成功。
+  // 【关键修改】增强重试机制
+  Future<T> _fetchWithRetry<T>(Future<T> Function() operation) async {
+    try {
+      return await operation();
+    } catch (e) {
+      // 只要是这些错误，统统重试
+      if (e is SessionExpiredException || 
+          e.toString().contains("未登录") || 
+          e.toString().contains("wisportalId无效") ||
+          e.toString().contains("无法解析")) { // 包含“无法解析”
+        
+        print("⚡️⚡️ 自动修复：检测到异常(${e.toString()})，正在重建连接并重试... ⚡️⚡️");
+        
+        // 1. 重新登录（会重置 HttpClient）
+        await login();
+        
+        // 2. 【关键】稍微等待一下，给服务器一点反应时间，也确保本地状态同步
+        await Future.delayed(const Duration(milliseconds: 500));
+        
+        // 3. 再次尝试
+        return await operation();
+      }
+      rethrow;
+    }
+  }
+
   @override
   Future<
       Tuple7<
@@ -129,26 +167,21 @@ class UgrsSpider implements Spider {
           List<double>,
           Map<DateTime, String>,
           List<Todo>>> getEverything() async {
-    // 请求顺序
     var fetches = <Future<String?>>[];
     List<String> fetchSequence = ['校历', '课表', '考试', '成绩', '主修', '作业', '实践'];
 
-    // 返回值初始化
     var outSemesters = <Semester>[];
     var outGrades = <Grade>[];
     var outMajorGrade = <double>[];
     var outSpecialDates = <DateTime, String>{};
     var outTodos = <Todo>[];
     var loginErrorMessages = <String?>[null, null, null];
-    // 暂存主修课程ID集合，待所有请求完成后再打标记
     var majorCourseIds = <String>{};
 
-    // 如果Cookie过期了，就重新登录
     if (DateTime.now().difference(_lastUpdateTime).inMinutes > 15) {
       loginErrorMessages = await login();
     }
 
-    // 建立学期编号与“入学以来第几个学期”的映射。如"2022-2023-1"对应第22年入学同学的第1个学期，即"2022-2023秋冬"。
     var yearNow = DateTime.now().year;
     var yearEnroll = int.parse(_username.substring(1, 3)) + 2000;
     var yearGraduate = yearEnroll + 7;
@@ -162,83 +195,65 @@ class UgrsSpider implements Spider {
       outSemesters.add(Semester('${yearEnroll + i}-${yearEnroll + i + 1}秋冬'));
     }
 
-    // 查校历（存在CDN上，JSON格式的，内含学期起止日期、单日时间表、放假调休等信息）
     var semesterConfigFetches = <Future<String?>>[];
-    // 查课表
     var timetableFetches = <Future<String?>>[];
     var cancelTimetableFetch = false;
 
     while (yearEnroll <= yearNow && yearEnroll <= yearGraduate) {
       var yearStr = '$yearEnroll-${yearEnroll + 1}';
+      
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-1').then((value) {
-        if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-1']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-        }
-        return value.item1?.toString();
-      }).catchError((e) => e.toString()));
+             if (value.item2 != null) {
+                outSemesters[semesterIndexMap['$yearStr-1']!]
+                    .addZjuCalendar(jsonDecode(value.item2!));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
+                    .map((k, v) =>
+                        MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
+                    .map((k, v) => MapEntry(
+                        DateTime.parse((k as String).substring(0, 8)),
+                        '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
+                    .map((k, v) => MapEntry(
+                        DateTime.parse((k as String).substring(8, 16)),
+                        '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
+                    (k, v) =>
+                        MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+              }
+             return value.item1?.toString();
+          }).catchError((e) => e.toString()));
+          
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-2').then((value) {
-        if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-2']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-        }
-        return value.item1?.toString();
-      }).catchError((e) => e.toString()));
+              if (value.item2 != null) {
+                outSemesters[semesterIndexMap['$yearStr-2']!]
+                    .addZjuCalendar(jsonDecode(value.item2!));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
+                    .map((k, v) =>
+                        MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
+                    .map((k, v) => MapEntry(
+                        DateTime.parse((k as String).substring(0, 8)),
+                        '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
+                    .map((k, v) => MapEntry(
+                        DateTime.parse((k as String).substring(8, 16)),
+                        '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+                outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
+                    (k, v) =>
+                        MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+              }
+              return value.item1?.toString();
+          }).catchError((e) => e.toString()));
 
-      // 查考试
-      /*examFetches
-          .add(_appService.getExamsDto(_httpClient, yearStr, "1").then((value) {
-        for (var e in value.item2) {
-          outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addExam(e);
-        }
-        return value.item1?.toString();
-      }).catchError((e) => e.toString()));
-      examFetches
-          .add(_appService.getExamsDto(_httpClient, yearStr, "2").then((value) {
-        for (var e in value.item2) {
-          outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addExam(e);
-        }
-        return value.item1?.toString();
-      }).catchError((e) => e.toString()));*/
 
-      // 本科生课
-      // 顺序获取课表
       Future<String?> handleTimetable(season) async {
-        if (cancelTimetableFetch) {
-          return Future.value("已取消");
-        }
+        if (cancelTimetableFetch) return Future.value("已取消");
         try {
-          var value = await _zdbk.getTimetable(_httpClient, yearStr, season);
+          var value = await _fetchWithRetry(() => _zdbk.getTimetable(_httpClient, yearStr, season));
+          
           var semKey = season.startsWith('1') ? '$yearStr-1' : '$yearStr-2';
           var sessions = value.item2.toList();
           sessions.sort((a, b) {
@@ -271,8 +286,9 @@ class UgrsSpider implements Spider {
         }
       }
 
-      // 研究生课与考试
-      if (fetchGrs) {
+if (fetchGrs) {
+        // ... (保持原研究生逻辑，此处省略以节省篇幅，请保留你原文件中的逻辑)
+        // 注意：如果原逻辑使用了 _httpClient，它会自动使用新的实例，因为是字段访问
         timetableFetches.add(
             _grsNew.getTimetable(_httpClient, yearEnroll, 13).then((value) {
           for (var e in value.item2) {
@@ -305,7 +321,6 @@ class UgrsSpider implements Spider {
           }
           return value.item1?.toString();
         }).catchError((e) => e.toString()));
-        // 研究生课的【考试】
         timetableFetches
             .add(_grsNew.getExamsDto(_httpClient, yearEnroll, 12).then((value) {
           for (var e in value.item2) {
@@ -326,22 +341,19 @@ class UgrsSpider implements Spider {
       yearEnroll++;
     }
 
-    // 配置
     fetches.add(Future.wait(semesterConfigFetches)
         .then((value) => value.firstWhereOrNull((e) => e != null)));
-    // 课表
     fetches.add(Future.wait(timetableFetches)
         .then((value) => value.firstWhereOrNull((e) => e != null)));
-    // 考试
-    fetches.add(_zdbk.getExamsDto(_httpClient).then((value) {
+        
+    fetches.add(_fetchWithRetry(() => _zdbk.getExamsDto(_httpClient)).then((value) {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addExam(e);
       }
       return value.item1?.toString();
     }).catchError((e) => e.toString()));
 
-    // 成绩
-    fetches.add(_zdbk.getTranscript(_httpClient).then((value) {
+    fetches.add(_fetchWithRetry(() => _zdbk.getTranscript(_httpClient)).then((value) {
       for (var e in value.item2) {
         outSemesters[semesterIndexMap[e.id.substring(1, 12)]!].addGrade(e);
         outGrades.add(e);
@@ -352,12 +364,10 @@ class UgrsSpider implements Spider {
       return value.item1?.toString();
     }).catchError((e) => e.toString()));
 
-    // 主修
-    fetches.add(_zdbk.getMajorGrade(_httpClient).then((value) {
+    fetches.add(_fetchWithRetry(() => _zdbk.getMajorGrade(_httpClient)).then((value) {
       outMajorGrade.clear();
       outMajorGrade.addAll(value.item2.item1);
 
-      // 获取主修课程的课程号列表并暂存
       var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
               .firstMatch(value.item2.item2)
               ?.group(0) ??
@@ -370,16 +380,13 @@ class UgrsSpider implements Spider {
       return value.item1?.toString();
     }).catchError((e) => e.toString()));
 
-    // 作业（学在浙大）
     fetches.add(_courses.getTodo(_httpClient).then((value) {
       outTodos.clear();
       outTodos.addAll(value.item2);
       return value.item1?.toString();
     }).catchError((e) => e.toString()));
 
-    // 实践学分（第二三四课堂）- 使用zdbk获取
-    fetches.add(_zdbk.getPracticeScores(_httpClient, _username).then((value) {
-      // 只有当没有错误时，才设置为 true
+    fetches.add(_fetchWithRetry(() => _zdbk.getPracticeScores(_httpClient, _username)).then((value) {
       if (value.item1 == null) {
         _practiceScores = value.item2;
         _isPracticeScoresGet = true;
@@ -393,7 +400,6 @@ class UgrsSpider implements Spider {
       return e.toString();
     }));
 
-    // 等待所有请求完成。然后，删除不包含考试、成绩、课程的全空学期
     var fetchErrorMessages = await Future.wait(fetches).whenComplete(() {
       outSemesters.removeWhere((e) =>
           e.grades.isEmpty &&
@@ -401,7 +407,6 @@ class UgrsSpider implements Spider {
           e.exams.isEmpty &&
           e.courses.isEmpty);
 
-      // 所有请求完成后，统一给主修课程打标记
       for (var grade in outGrades) {
         if (majorCourseIds.contains(grade.id)) {
           grade.major = true;
@@ -409,7 +414,6 @@ class UgrsSpider implements Spider {
       }
     });
 
-    // 检查是否有查询失败的情况
     if (fetchErrorMessages.every((e) => e == null)) {
       _lastUpdateTime = DateTime.now();
     }
@@ -447,7 +451,7 @@ class MockSpider extends UgrsSpider {
 
   @override
   void logout() {}
-
+  
   @override
   Future<
       Tuple7<

--- a/lib/http/zjuServices/grs_new.dart
+++ b/lib/http/zjuServices/grs_new.dart
@@ -13,6 +13,7 @@ import 'package:quiver/time.dart';
 
 class GrsNew {
   String? _token;
+  Cookie? _ssoCookie; // ← 【新增】保存登录凭据，以便自动重登
   // ignore: unused_field
   DatabaseHelper? _db;
 
@@ -27,6 +28,8 @@ class GrsNew {
     if (ssoCookie == null) {
       throw ExceptionWithMessage("Invalid ssoCookie");
     }
+
+    _ssoCookie = ssoCookie; // ← 【新增】保存凭据
 
     req = await httpClient
         .getUrl(Uri.parse(
@@ -72,18 +75,52 @@ class GrsNew {
 
   void logout() {
     _token = null;
+    _ssoCookie = null; // ← 【新增】退出时也清除
   }
+
+  // ===== 【新增】自动重登辅助方法 =====
+  // 当 _token 失效时，用保存的 _ssoCookie 自动重新登录
+  Future<void> _relogin(HttpClient httpClient) async {
+    if (_ssoCookie == null) {
+      throw ExceptionWithMessage("会话已过期，请重新登录");
+    }
+    _token = null; // 清掉旧的失效token
+    await login(httpClient, _ssoCookie);
+  }
+
+  // 检查API返回结果是否表示token已失效
+  bool _isTokenExpired(Map<String, dynamic> result) {
+    if (result["success"] == false) {
+      String msg = (result["message"] ?? "").toString().toLowerCase();
+      if (msg.contains("token") ||
+          msg.contains("登录") ||
+          msg.contains("unauthorized") ||
+          msg.contains("认证") ||
+          msg.contains("过期")) {
+        return true;
+      }
+      // 研究生教务系统在token过期时返回code 401或500
+      var code = result["code"];
+      if (code == 401 || code == 500) {
+        return true;
+      }
+    }
+    return false;
+  }
+  // ===== 【新增结束】 =====
 
   Future<Tuple<Exception?, Iterable<Grade>>> getGrade(
       HttpClient httpClient) async {
-    /*
-    不需要参数，但是注意是post
-     */
     late HttpClientRequest req;
     late HttpClientResponse res;
     try {
       if (_token == null) {
-        throw ExceptionWithMessage("not logged in");
+        // 【改动】不再直接报错，而是尝试自动重登
+        if (_ssoCookie != null) {
+          await _relogin(httpClient);
+        } else {
+          throw ExceptionWithMessage("not logged in");
+        }
       }
       req = await httpClient
           .postUrl(Uri.parse(
@@ -95,54 +132,31 @@ class GrsNew {
           onTimeout: () => throw ExceptionWithMessage("request timeout"));
       final resultJson = await res.transform(utf8.decoder).join();
       final result = jsonDecode(resultJson) as Map<String, dynamic>;
+
+      // 【新增】检查token是否过期，过期则自动重登再重试一次
+      if (_isTokenExpired(result)) {
+        await _relogin(httpClient);
+        req = await httpClient
+            .postUrl(Uri.parse(
+                "https://yjsy.zju.edu.cn/dataapi/py/pyXsxk/queryXsxkByXnxqXs"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        req.headers.add("X-Access-Token", _token!);
+        res = await req.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        final retryJson = await res.transform(utf8.decoder).join();
+        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
+        if (retryResult["success"] != true) {
+          throw ExceptionWithMessage('获取成绩api错误，错误信息为 ${retryResult["message"]}');
+        }
+        return _parseGrades(retryResult);
+      }
+
       if (result["success"] != true) {
         throw ExceptionWithMessage('获取成绩api错误，错误信息为 ${result["message"]}');
       }
 
-      final rawGrades = (result["result"]?["xxjhnList"] as List?) ?? [];
-      if (rawGrades.isEmpty) {
-        return Tuple(null, <Grade>[]);
-      }
-      List<Grade> grades = [];
-
-      for (var rawGradeDyn in rawGrades) {
-        var rawGrade = rawGradeDyn as Map<String, dynamic>;
-        // TODO: 增加额外的需要跳过的课程
-        if (rawGrade["xkztMc"] == "未处理") {
-          continue;
-        }
-        var newGrade = Grade.empty();
-        //这里使用的id和其他的不一样，直接使用sjddBz字段，
-        // e.g.: 2023-2024学年冬学期<br/>班级编号xxxxx
-        newGrade.id =
-            rawGrade["sjddBz"] == null ? "" : rawGrade["sjddBz"] as String;
-        newGrade.name = rawGrade["kcmc"] as String;
-        newGrade.credit = rawGrade["xf"] as double;
-
-        if (rawGrade["bz"] != null) {
-          var comments = rawGrade["bz"] as String;
-          if (comments.contains("线上") ||
-              comments.contains("录播") ||
-              comments.contains("直播")) {
-            newGrade.isOnline = true;
-          } else {
-            newGrade.isOnline = false;
-          }
-        } else {
-          newGrade.isOnline = false;
-        }
-        newGrade.fivePoint = 0.0;
-        newGrade.fourPoint = 0.0;
-        newGrade.fourPointLegacy = 0.0;
-        newGrade.hundredPoint =
-            rawGrade["zf"] == null ? 0 : (rawGrade["zf"] as double).toInt();
-        newGrade.major = true;
-        // 研究生应该没法算gpa吧
-        newGrade.gpaIncluded = false;
-        newGrade.creditIncluded = true;
-        grades.add(newGrade);
-      }
-      return Tuple(null, grades);
+      return _parseGrades(result);
     } catch (e) {
       var exception =
           e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
@@ -150,17 +164,62 @@ class GrsNew {
     }
   }
 
+  // 【新增】把成绩解析提取成单独方法，避免重复代码
+  Tuple<Exception?, Iterable<Grade>> _parseGrades(Map<String, dynamic> result) {
+    final rawGrades = (result["result"]?["xxjhnList"] as List?) ?? [];
+    if (rawGrades.isEmpty) {
+      return Tuple(null, <Grade>[]);
+    }
+    List<Grade> grades = [];
+
+    for (var rawGradeDyn in rawGrades) {
+      var rawGrade = rawGradeDyn as Map<String, dynamic>;
+      if (rawGrade["xkztMc"] == "未处理") {
+        continue;
+      }
+      var newGrade = Grade.empty();
+      newGrade.id =
+          rawGrade["sjddBz"] == null ? "" : rawGrade["sjddBz"] as String;
+      newGrade.name = rawGrade["kcmc"] as String;
+      newGrade.credit = rawGrade["xf"] as double;
+
+      if (rawGrade["bz"] != null) {
+        var comments = rawGrade["bz"] as String;
+        if (comments.contains("线上") ||
+            comments.contains("录播") ||
+            comments.contains("直播")) {
+          newGrade.isOnline = true;
+        } else {
+          newGrade.isOnline = false;
+        }
+      } else {
+        newGrade.isOnline = false;
+      }
+      newGrade.fivePoint = 0.0;
+      newGrade.fourPoint = 0.0;
+      newGrade.fourPointLegacy = 0.0;
+      newGrade.hundredPoint =
+          rawGrade["zf"] == null ? 0 : (rawGrade["zf"] as double).toInt();
+      newGrade.major = true;
+      newGrade.gpaIncluded = false;
+      newGrade.creditIncluded = true;
+      grades.add(newGrade);
+    }
+    return Tuple(null, grades);
+  }
+
   Future<Tuple<Exception?, Iterable<ExamDto>>> getExamsDto(
       HttpClient httpClient, int year, int semester) async {
-    /*
-    * 11 srping-summer
-    * 12 autum-winter
-     */
     late HttpClientRequest req;
     late HttpClientResponse res;
     try {
       if (_token == null) {
-        throw ExceptionWithMessage("not logged in");
+        // 【改动】不再直接报错，而是尝试自动重登
+        if (_ssoCookie != null) {
+          await _relogin(httpClient);
+        } else {
+          throw ExceptionWithMessage("not logged in");
+        }
       }
 
       req = await httpClient
@@ -173,47 +232,31 @@ class GrsNew {
           onTimeout: () => throw ExceptionWithMessage("request timeout"));
       final resultJson = await res.transform(utf8.decoder).join();
       final result = jsonDecode(resultJson) as Map<String, dynamic>;
+
+      // 【新增】检查token是否过期
+      if (_isTokenExpired(result)) {
+        await _relogin(httpClient);
+        req = await httpClient
+            .getUrl(Uri.parse(
+                "https://yjsy.zju.edu.cn/dataapi/py/pyKsxsxx/queryPageByXs?dm=py_grks&mode=2&role=1&column=createTime&order=desc&queryMode=1&field=id,,kcbh,kcmc,rq,ksTime,xn,xq_dictText,ksdd,zwh&pageNo=1&pageSize=100&xn=$year&xq=$semester"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        req.headers.add("X-Access-Token", _token!);
+        res = await req.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        final retryJson = await res.transform(utf8.decoder).join();
+        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
+        if (retryResult["success"] != true) {
+          throw ExceptionWithMessage("获取考试api错误，错误信息为 ${retryResult["message"]}");
+        }
+        return _parseExams(retryResult, year);
+      }
+
       if (result["success"] != true) {
         throw ExceptionWithMessage("获取考试api错误，错误信息为 ${result["message"]}");
       }
 
-      final rawExams = result["result"] as List<dynamic>;
-      List<ExamDto> exams = [];
-      // 这个破库不支持yyyyMMdd格式的表示，必须有分隔符
-      final formatter = DateFormat('yyyy-MM-dd');
-
-      for (var rawExamDyn in rawExams) {
-        var rawExam = rawExamDyn as Map<String, dynamic>;
-        // yjsy系统奇怪的bug，加一个特判
-        if (rawExam["xn"] as String != year.toString()) {
-          continue;
-        }
-        var newExamDto = ExamDto.empty();
-        var newExam = Exam.empty();
-        newExam.id = (rawExam["kcbh"] as String).substring(0, 7);
-        newExam.name = rawExam["kcmc"] as String;
-        newExam.type = ExamType.finalExam;
-        newExam.location = (rawExam["mc"] as String?) ?? "未知地点";
-        newExam.seat = (rawExam["zwh"] as int).toString();
-        int day = (rawExam["rq"] as int?) ?? 19700101;
-        int start = (rawExam["kssj"] as int?) ?? 800;
-        int end = (rawExam["jssj"] as int?) ?? 2200;
-        String dayFromat =
-            '${day.toString().substring(0, 4)}-${day.toString().substring(4, 6)}-${day.toString().substring(6, 8)}';
-        DateTime dayTime = formatter.parse(dayFromat);
-        DateTime startTime =
-            dayTime.add(anHour * (start ~/ 100) + aMinute * (start % 100));
-        DateTime endTime =
-            dayTime.add(anHour * (end ~/ 100) + aMinute * (end % 100));
-        newExam.time = [startTime, endTime];
-        newExamDto.id = (rawExam["kcbh"] as String).substring(0, 7);
-        newExamDto.name = rawExam["kcmc"] as String;
-        newExamDto.credit = 0;
-        newExamDto.exams.add(newExam);
-
-        exams.add(newExamDto);
-      }
-      return Tuple(null, exams);
+      return _parseExams(result, year);
     } catch (e) {
       var exception =
           e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
@@ -221,10 +264,48 @@ class GrsNew {
     }
   }
 
+  // 【新增】把考试解析提取成单独方法
+  Tuple<Exception?, Iterable<ExamDto>> _parseExams(
+      Map<String, dynamic> result, int year) {
+    final rawExams = result["result"] as List<dynamic>;
+    List<ExamDto> exams = [];
+    final formatter = DateFormat('yyyy-MM-dd');
+
+    for (var rawExamDyn in rawExams) {
+      var rawExam = rawExamDyn as Map<String, dynamic>;
+      if (rawExam["xn"] as String != year.toString()) {
+        continue;
+      }
+      var newExamDto = ExamDto.empty();
+      var newExam = Exam.empty();
+      newExam.id = (rawExam["kcbh"] as String).substring(0, 7);
+      newExam.name = rawExam["kcmc"] as String;
+      newExam.type = ExamType.finalExam;
+      newExam.location = (rawExam["mc"] as String?) ?? "未知地点";
+      newExam.seat = (rawExam["zwh"] as int).toString();
+      int day = (rawExam["rq"] as int?) ?? 19700101;
+      int start = (rawExam["kssj"] as int?) ?? 800;
+      int end = (rawExam["jssj"] as int?) ?? 2200;
+      String dayFromat =
+          '${day.toString().substring(0, 4)}-${day.toString().substring(4, 6)}-${day.toString().substring(6, 8)}';
+      DateTime dayTime = formatter.parse(dayFromat);
+      DateTime startTime =
+          dayTime.add(anHour * (start ~/ 100) + aMinute * (start % 100));
+      DateTime endTime =
+          dayTime.add(anHour * (end ~/ 100) + aMinute * (end % 100));
+      newExam.time = [startTime, endTime];
+      newExamDto.id = (rawExam["kcbh"] as String).substring(0, 7);
+      newExamDto.name = rawExam["kcmc"] as String;
+      newExamDto.credit = 0;
+      newExamDto.exams.add(newExam);
+
+      exams.add(newExamDto);
+    }
+    return Tuple(null, exams);
+  }
+
   // Helper method to map semester code to semester name
   String _getSemesterName(int semester) {
-    // 11: spring, 15: spring-summer -> "春夏学期"
-    // 12: summer, 13: autumn, 14: winter, 16: autumn-winter -> "秋冬学期"
     if (semester == 11 || semester == 15) {
       return "春夏学期";
     } else {
@@ -232,23 +313,10 @@ class GrsNew {
     }
   }
 
-  /// 根据课程列表 sessions，通过研究生教务系统课程详情 API 补全每门课程的学分、上课方式（线上/线下）、课程类型等详细信息。
-  ///
-  /// 参数说明：
-  /// [httpClient] - Dart 的 HttpClient 实例，用于发起 API 请求。
-  /// [year] - 学年（如 2023），等同于 API 参数 xns。
-  /// [semester] - 学期代码，Semester 枚举值（11/12/13/14/15/16），等同于 API 参数 pkxq。
-  /// [sessions] - 课程 Session 对象列表，需要补全详细信息的课程列表。
-  ///
-  /// 用法示例：
-  ///   await _fetchCourseDetails(httpClient, 2023, 13, sessions);
-  ///
-  /// 注意：必须先登录获取 _token，否则不会进行任何操作。
   Future<void> _fetchCourseDetails(HttpClient httpClient, int year,
       int semester, List<Session> sessions) async {
     if (_token == null) return;
 
-    // 将 sessions 按课程 id 归类，以便批量更新同一课程可能出现的多条 session 信息
     Map<String, List<Session>> sessionsByCourse = {};
     for (var session in sessions) {
       if (session.id != null) {
@@ -262,20 +330,17 @@ class GrsNew {
       List<Session> courseSessions = entry.value;
       String? teacherId = courseSessions.first.teacherId;
 
-      // 没有教师信息的不查（课表 API 异常情况下可出现）
       if (teacherId == null || teacherId.isEmpty) return;
 
       try {
-        // Build URL with parameters
-        // 对应研究生教务系统的查询全校开课情况接口
         String url =
             "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryKcbjDetailInfoPage?";
         url += "&xns=$year";
-        url += "&xqMc=${Uri.encodeComponent(semesterName)}"; // 学期名称
-        url += "&kcbh=${Uri.encodeComponent(sessionId)}"; // 课程ID
+        url += "&xqMc=${Uri.encodeComponent(semesterName)}";
+        url += "&kcbh=${Uri.encodeComponent(sessionId)}";
         url +=
-            "&kcmc=${Uri.encodeComponent(courseSessions.first.name)}"; // 课程名称
-        url += "&zjjsJzgId=${Uri.encodeComponent(teacherId)}"; // 教师ID
+            "&kcmc=${Uri.encodeComponent(courseSessions.first.name)}";
+        url += "&zjjsJzgId=${Uri.encodeComponent(teacherId)}";
         var req = await httpClient.getUrl(Uri.parse(url)).timeout(
             const Duration(seconds: 8),
             onTimeout: () => throw ExceptionWithMessage("request timeout"));
@@ -285,38 +350,26 @@ class GrsNew {
 
         final resultJson = await res.transform(utf8.decoder).join();
         final result = jsonDecode(resultJson) as Map<String, dynamic>;
-        if (result["success"] == true) {
-          final records = result["result"]?["records"] as List?;
-          if (records != null && records.isNotEmpty) {
-            var detail = records[0] as Map<String, dynamic>;
 
-            // 抓取学分
-            if (detail["xf"] != null) {
-              double creditValue = (detail["xf"] as num).toDouble();
-              for (var session in courseSessions) {
-                session.credit = creditValue;
-              }
-            }
-
-            // 抓取是否线上课程
-            if (detail["bz"] != null) {
-              String comments = detail["bz"] as String;
-              bool isOnline = comments.contains("线上") ||
-                  comments.contains("录播") ||
-                  comments.contains("直播");
-              for (var session in courseSessions) {
-                session.online = isOnline;
-              }
-            }
-
-            // 抓取课程类型（专业学位课、公共学位课、专业必修课、公共必修课、专业选修课、公共选修课）
-            if (detail["kcxzDm_dictText"] != null) {
-              String courseType = detail["kcxzDm_dictText"] as String;
-              for (var session in courseSessions) {
-                session.type = courseType;
-              }
-            }
+        // 【新增】如果token过期，尝试重登再重试
+        if (_isTokenExpired(result) && _ssoCookie != null) {
+          await _relogin(httpClient);
+          req = await httpClient.getUrl(Uri.parse(url)).timeout(
+              const Duration(seconds: 8),
+              onTimeout: () => throw ExceptionWithMessage("request timeout"));
+          req.headers.add("X-Access-Token", _token!);
+          res = await req.close().timeout(const Duration(seconds: 8),
+              onTimeout: () => throw ExceptionWithMessage("request timeout"));
+          final retryJson = await res.transform(utf8.decoder).join();
+          final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
+          if (retryResult["success"] == true) {
+            _applyCourseDetails(retryResult, courseSessions);
           }
+          return;
+        }
+
+        if (result["success"] == true) {
+          _applyCourseDetails(result, courseSessions);
         }
       } catch (e) {
         // 若接口访问或解包异常，课程信息维持原值，不做抛出
@@ -324,22 +377,51 @@ class GrsNew {
     }));
   }
 
+  // 【新增】把课程详情解析提取成独立方法
+  void _applyCourseDetails(
+      Map<String, dynamic> result, List<Session> courseSessions) {
+    final records = result["result"]?["records"] as List?;
+    if (records != null && records.isNotEmpty) {
+      var detail = records[0] as Map<String, dynamic>;
+
+      if (detail["xf"] != null) {
+        double creditValue = (detail["xf"] as num).toDouble();
+        for (var session in courseSessions) {
+          session.credit = creditValue;
+        }
+      }
+
+      if (detail["bz"] != null) {
+        String comments = detail["bz"] as String;
+        bool isOnline = comments.contains("线上") ||
+            comments.contains("录播") ||
+            comments.contains("直播");
+        for (var session in courseSessions) {
+          session.online = isOnline;
+        }
+      }
+
+      if (detail["kcxzDm_dictText"] != null) {
+        String courseType = detail["kcxzDm_dictText"] as String;
+        for (var session in courseSessions) {
+          session.type = courseType;
+        }
+      }
+    }
+  }
+
   Future<Tuple<Exception?, Iterable<Session>>> getTimetable(
       HttpClient httpClient, int year, int semester) async {
-    /*
-     * semester:
-     * 11: spring
-     * 12: summer
-     * 13: autumn
-     * 14: winter
-     * 15: spring-summer
-     * 16: autumn-winter
-     */
     late HttpClientRequest req;
     late HttpClientResponse res;
     try {
       if (_token == null) {
-        throw ExceptionWithMessage("not logged in");
+        // 【改动】不再直接报错，而是尝试自动重登
+        if (_ssoCookie != null) {
+          await _relogin(httpClient);
+        } else {
+          throw ExceptionWithMessage("not logged in");
+        }
       }
 
       req = await httpClient
@@ -353,108 +435,129 @@ class GrsNew {
       final resultJson = await res.transform(utf8.decoder).join();
 
       final result = jsonDecode(resultJson) as Map<String, dynamic>;
+
+      // 【新增】检查token是否过期
+      if (_isTokenExpired(result)) {
+        await _relogin(httpClient);
+        req = await httpClient
+            .getUrl(Uri.parse(
+                "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryXskbByLoginUser?xn=$year&pkxq=$semester"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        req.headers.add("X-Access-Token", _token!);
+        res = await req.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("request timeout"));
+        final retryJson = await res.transform(utf8.decoder).join();
+        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
+        if (retryResult["success"] != true) {
+          throw ExceptionWithMessage("获取课程api错误，错误信息为 ${retryResult["message"]}");
+        }
+        return _parseTimetable(httpClient, retryResult, year, semester);
+      }
+
       if (result["success"] != true) {
         throw ExceptionWithMessage("获取课程api错误，错误信息为 ${result["message"]}");
       }
 
-      Map<String, dynamic> defaultMap = {};
-      final kcbMap = result["result"] as Map<String, dynamic>;
-      final dayWithClasses = kcbMap["kcbMap"] as Map<String, dynamic>;
-
-      List<Session> sessions = [];
-      for (int i = 1; i <= 7; ++i) {
-        var classesThisDay =
-            (dayWithClasses["$i"] ?? defaultMap) as Map<String, dynamic>;
-        Map<String, Session> sessionThisDay = {};
-        for (int j = 1; j <= 15; ++j) {
-          var wrapper =
-              (classesThisDay["$j"] ?? defaultMap) as Map<String, dynamic>;
-          var classesThisPeriod =
-              (wrapper["pyKcbjSjddVOList"] ?? []) as List<dynamic>;
-
-          for (var rawClassDyn in classesThisPeriod) {
-            try {
-              var rawClass = rawClassDyn as Map<String, dynamic>;
-              String classId = rawClass["bjbh"] as String;
-              String sessionId = classId.substring(0, 7);
-
-              if (sessionThisDay.containsKey(classId)) {
-                sessionThisDay[classId]!.time.add(j);
-                continue;
-              }
-              // TODO: 增加还需要跳过的课程，"12"=未处理
-              if (rawClass["xkzt"] == "12") {
-                continue;
-              }
-
-              int classSemester = int.parse(rawClass["pkxq"] ?? "$semester");
-              var newSession = Session.empty();
-              newSession.id = sessionId;
-              newSession.name = rawClass["kcmc"] as String;
-              newSession.teacher = rawClass["xm"] as String;
-              newSession.teacherId = rawClass["jzgId"] as String?;
-              newSession.location = rawClass["cdmc"] as String?;
-              newSession.confirmed = true;
-              newSession.dayOfWeek = i;
-              newSession.time = [j];
-
-              if (semester == 11 || semester == 13) {
-                newSession.firstHalf = true;
-              } else {
-                newSession.secondHalf = true;
-              }
-              if (classSemester == 15 || classSemester == 16) {
-                newSession.firstHalf = newSession.secondHalf = true;
-              }
-
-              // 研究生教务系统的课表在改版之后就是依托答辩，哪个没脑子的能想出来把调休的课单独列出来？
-              // 课表和狗皮膏药一样完全读不懂，“秋冬1,2,4,5,6,7,8,9,10,11,12,13,14,15,16周上课”这玩意儿是给人看的？
-              String weekExtra = rawClass["zc"] as String;
-              weekExtra = weekExtra.replaceAll(RegExp(r"[^\d,]"), "");
-              List<int> weekExtraList =
-                  weekExtra.split(",").map(int.parse).toList();
-
-              newSession.customRepeat = true;
-              newSession.customRepeatWeeks = weekExtraList;
-
-              var threshold =
-                  (newSession.firstHalf && newSession.secondHalf) ? 8 : 4;
-              if (weekExtraList.length > threshold) {
-                newSession.oddWeek = newSession.evenWeek = true;
-              } else {
-                int oddWeekCount =
-                    weekExtraList.where((e) => e % 2 == 1).length;
-                if (oddWeekCount > weekExtraList.length / 2) {
-                  newSession.oddWeek = true;
-                } else {
-                  newSession.evenWeek = true;
-                }
-              }
-
-              sessionThisDay[classId] = newSession;
-            } finally {
-              // log here?
-            }
-          }
-        }
-
-        sessions.addAll(sessionThisDay.values);
-      }
-
-      // Fetch course details for each unique course
-      await _fetchCourseDetails(httpClient, year, semester, sessions);
-
-      return Tuple(null, sessions);
+      return _parseTimetable(httpClient, result, year, semester);
     } catch (e) {
       var exception =
           e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
       return Tuple(exception, []);
     }
   }
+
+  // 【新增】把课表解析提取成独立方法
+  Future<Tuple<Exception?, Iterable<Session>>> _parseTimetable(
+      HttpClient httpClient,
+      Map<String, dynamic> result,
+      int year,
+      int semester) async {
+    Map<String, dynamic> defaultMap = {};
+    final kcbMap = result["result"] as Map<String, dynamic>;
+    final dayWithClasses = kcbMap["kcbMap"] as Map<String, dynamic>;
+
+    List<Session> sessions = [];
+    for (int i = 1; i <= 7; ++i) {
+      var classesThisDay =
+          (dayWithClasses["$i"] ?? defaultMap) as Map<String, dynamic>;
+      Map<String, Session> sessionThisDay = {};
+      for (int j = 1; j <= 15; ++j) {
+        var wrapper =
+            (classesThisDay["$j"] ?? defaultMap) as Map<String, dynamic>;
+        var classesThisPeriod =
+            (wrapper["pyKcbjSjddVOList"] ?? []) as List<dynamic>;
+
+        for (var rawClassDyn in classesThisPeriod) {
+          try {
+            var rawClass = rawClassDyn as Map<String, dynamic>;
+            String classId = rawClass["bjbh"] as String;
+            String sessionId = classId.substring(0, 7);
+
+            if (sessionThisDay.containsKey(classId)) {
+              sessionThisDay[classId]!.time.add(j);
+              continue;
+            }
+            if (rawClass["xkzt"] == "12") {
+              continue;
+            }
+
+            int classSemester = int.parse(rawClass["pkxq"] ?? "$semester");
+            var newSession = Session.empty();
+            newSession.id = sessionId;
+            newSession.name = rawClass["kcmc"] as String;
+            newSession.teacher = rawClass["xm"] as String;
+            newSession.teacherId = rawClass["jzgId"] as String?;
+            newSession.location = rawClass["cdmc"] as String?;
+            newSession.confirmed = true;
+            newSession.dayOfWeek = i;
+            newSession.time = [j];
+
+            if (semester == 11 || semester == 13) {
+              newSession.firstHalf = true;
+            } else {
+              newSession.secondHalf = true;
+            }
+            if (classSemester == 15 || classSemester == 16) {
+              newSession.firstHalf = newSession.secondHalf = true;
+            }
+
+            String weekExtra = rawClass["zc"] as String;
+            weekExtra = weekExtra.replaceAll(RegExp(r"[^\d,]"), "");
+            List<int> weekExtraList =
+                weekExtra.split(",").map(int.parse).toList();
+
+            newSession.customRepeat = true;
+            newSession.customRepeatWeeks = weekExtraList;
+
+            var threshold =
+                (newSession.firstHalf && newSession.secondHalf) ? 8 : 4;
+            if (weekExtraList.length > threshold) {
+              newSession.oddWeek = newSession.evenWeek = true;
+            } else {
+              int oddWeekCount =
+                  weekExtraList.where((e) => e % 2 == 1).length;
+              if (oddWeekCount > weekExtraList.length / 2) {
+                newSession.oddWeek = true;
+              } else {
+                newSession.evenWeek = true;
+              }
+            }
+
+            sessionThisDay[classId] = newSession;
+          } finally {
+            // log here?
+          }
+        }
+      }
+
+      sessions.addAll(sessionThisDay.values);
+    }
+
+    await _fetchCourseDetails(httpClient, year, semester, sessions);
+
+    return Tuple(null, sessions);
+  }
 }
 
-void main() async {
-  // const str = "https://yjsy.zju.edu.cn/?ticket=ST-399";
-  // int ticketLoc = str.indexOf("ticket=");
-  // print(str.substring(ticketLoc + 7, 2));
-}
+void main() async {}

--- a/lib/http/zjuServices/zdbk.dart
+++ b/lib/http/zjuServices/zdbk.dart
@@ -20,6 +20,7 @@ class SessionExpiredException extends ExceptionWithMessage {
 class Zdbk {
   Cookie? _jSessionId;
   Cookie? _route;
+  Cookie? _iPlanetDirectoryPro; // 新增：保存登录凭据
   String? _captcha;
   DatabaseHelper? _db;
 
@@ -27,11 +28,12 @@ class Zdbk {
     _db = db;
   }
 
-  Future<bool> login(HttpClient httpClient, Cookie? iPlanetDirectoryPro) async {
+    Future<bool> login(HttpClient httpClient, Cookie? iPlanetDirectoryPro) async {
     late HttpClientRequest request;
     late HttpClientResponse response;
 
     _captcha = null;
+    _iPlanetDirectoryPro = iPlanetDirectoryPro; // 保存以便自动重登
 
     if (iPlanetDirectoryPro == null) {
       throw ExceptionWithMessage("iPlanetDirectoryPro无效");
@@ -61,8 +63,8 @@ class Zdbk {
         onTimeout: () => throw ExceptionWithMessage("请求超时"));
     response.drain();
 
-    if (response.cookies.any((element) =>
-        element.name == 'JSESSIONID' && element.path == '/jwglxt')) {
+    if (response.cookies.any(
+        (element) => element.name == 'JSESSIONID' && element.path == '/jwglxt')) {
       _jSessionId = response.cookies.firstWhere((element) =>
           element.name == 'JSESSIONID' && element.path == '/jwglxt');
     } else {
@@ -70,8 +72,7 @@ class Zdbk {
     }
 
     if (response.cookies.any((element) => element.name == 'route')) {
-      _route =
-          response.cookies.firstWhere((element) => element.name == 'route');
+      _route = response.cookies.firstWhere((element) => element.name == 'route');
     } else {
       throw ExceptionWithMessage("无法获取route");
     }
@@ -98,369 +99,406 @@ class Zdbk {
     }
   }
 
+  Future<void> _relogin(HttpClient httpClient) async {
+    if (_iPlanetDirectoryPro == null) {
+      throw ExceptionWithMessage("会话已过期，请重新登录");
+    }
+    await login(httpClient, _iPlanetDirectoryPro);
+  }
+
+  Future<T> _withAutoRelogin<T>(
+      HttpClient httpClient, Future<T> Function() action) async {
+    for (var i = 0; i < 2; i++) {
+      try {
+        if (_jSessionId == null || _route == null) {
+          await _relogin(httpClient);
+        }
+        return await action();
+      } on SessionExpiredException {
+        await _relogin(httpClient);
+      }
+    }
+    throw ExceptionWithMessage("会话已过期且自动重登失败");
+  }
+
   Future<Tuple<Exception?, Tuple<List<double>, String>>> getMajorGrade(
       HttpClient httpClient) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
+    return await _withAutoRelogin(httpClient, () async {
+      late HttpClientRequest request;
+      late HttpClientResponse response;
 
-    try {
-      if (_jSessionId == null || _route == null) {
-        throw SessionExpiredException();
-      }
-      request = await httpClient
-          .postUrl(Uri.parse(
-              "https://zdbk.zju.edu.cn/jwglxt/zycjtj/xszgkc_cxXsZgkcIndex.html?doType=query&queryModel.showCount=5000"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-      // 【关键修改】添加 Referer
-      request.headers.add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html");
-      request.cookies.add(_jSessionId!);
-      request.cookies.add(_route!);
-      request.followRedirects = false;
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
-
-      var responseText = await response.transform(utf8.decoder).join();
-      _checkSessionExpired(response, responseText);
-
-      var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
-          .firstMatch(responseText)
-          ?.group(0);
-      if (transcriptJson == null) throw ExceptionWithMessage("无法解析主修成绩");
-
-      var grades = (jsonDecode(transcriptJson) as List<dynamic>)
-          .where((e) => e['xkkh'] != null)
-          .map((e) {
-        var grade = Grade(e);
-        grade.major = true;
-        return grade;
-      });
-      var majorGpa = GpaHelper.calculateGpa(grades);
-      _db?.setCachedWebPage('zdbk_MajorGrade', transcriptJson);
-      return Tuple(
-          null, Tuple([majorGpa.item1[0], majorGpa.item2], responseText));
-    } catch (e) {
-      if (e is SessionExpiredException) rethrow;
-
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      var cachedJson = _db?.getCachedWebPage('zdbk_MajorGrade') ?? '[]';
-      var grades = (jsonDecode(cachedJson) as List<dynamic>)
-          .where((e) => e['xkkh'] != null)
-          .map((e) {
-        var grade = Grade(e);
-        grade.major = true;
-        return grade;
-      });
-      var majorGpa = GpaHelper.calculateGpa(grades);
-      return Tuple(
-          exception,
-          Tuple([majorGpa.item1[0], majorGpa.item2],
-              '{"items":$cachedJson,"limit":0}'));
-    }
-  }
-
-  Future<Tuple<Exception?, Iterable<Grade>>> getTranscript(
-      HttpClient httpClient) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
-
-    try {
-      if (_jSessionId == null || _route == null) {
-        throw SessionExpiredException();
-      }
-      request = await httpClient
-          .postUrl(Uri.parse(
-              "https://zdbk.zju.edu.cn/jwglxt/cxdy/xscjcx_cxXscjIndex.html?doType=query&queryModel.showCount=5000"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-      // 【关键修改】添加 Referer
-      request.headers.add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html");
-      request.cookies.add(_jSessionId!);
-      request.cookies.add(_route!);
-      request.followRedirects = false;
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
-
-      var responseText = await response.transform(utf8.decoder).join();
-      _checkSessionExpired(response, responseText);
-
-      var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
-          .firstMatch(responseText)
-          ?.group(0);
-      if (transcriptJson == null) throw ExceptionWithMessage("无法解析成绩");
-
-      var grades = (jsonDecode(transcriptJson) as List<dynamic>)
-          .where((e) => e['xkkh'] != null)
-          .map((e) => Grade(e));
-      _db?.setCachedWebPage('zdbk_Transcript', transcriptJson);
-      return Tuple(null, grades);
-    } catch (e) {
-      if (e is SessionExpiredException) rethrow;
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      return Tuple(
-          exception,
-          (jsonDecode((_db?.getCachedWebPage('zdbk_Transcript') ?? '[]'))
-                  as List<dynamic>)
-              .where((e) => e['xkkh'] != null)
-              .map((e) => Grade(e)));
-    }
-  }
-
-  Future<Tuple<Exception?, Iterable<Session>>> getTimetable(
-      HttpClient httpClient, String year, String semester) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
-
-    try {
-      if (_jSessionId == null || _route == null) {
-        throw SessionExpiredException();
-      }
-
-      for (var i = 0; i < 3; i++) {
+      try {
         request = await httpClient
             .postUrl(Uri.parse(
-                "https://zdbk.zju.edu.cn/jwglxt/kbcx/xskbcx_cxXsKb.html"))
+                "https://zdbk.zju.edu.cn/jwglxt/zycjtj/xszgkc_cxXsZgkcIndex.html?doType=query&queryModel.showCount=5000"))
             .timeout(const Duration(seconds: 8),
                 onTimeout: () => throw ExceptionWithMessage("请求超时"));
-        // 【关键修改】添加 Referer
-        request.headers.add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html");
+        request.headers
+          ..add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html")
+          ..set('Connection', 'close')
+          ..add(
+              'User-Agent',
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+          ..add('Accept', 'application/json, text/javascript, */*; q=0.01')
+          ..add('X-Requested-With', 'XMLHttpRequest');
         request.cookies.add(_jSessionId!);
         request.cookies.add(_route!);
-        request.headers.contentType = ContentType(
-            'application', 'x-www-form-urlencoded',
-            charset: 'utf-8');
-        request.headers.add('X-Requested-With', 'XMLHttpRequest');
-        request.add(
-            utf8.encode('xnm=$year&xqm=$semester&captcha_value=$_captcha'));
+        request.followRedirects = false;
         response = await request.close().timeout(const Duration(seconds: 8),
             onTimeout: () => throw ExceptionWithMessage("请求超时"));
 
         var responseText = await response.transform(utf8.decoder).join();
         _checkSessionExpired(response, responseText);
 
-        if (responseText.contains("captcha_error")) {
-          _captcha = null;
-          if (GlobalStatus.isFirstScreenReq) {
-            throw ExceptionWithMessage("需要验证码");
-          }
-          var imageBytes = await getCaptcha(httpClient);
-          var captcha = await ImageCodePortal.show(
-              imageBytes: imageBytes,
-              onRefresh: () async {
-                return await getCaptcha(httpClient);
-              });
-          if (captcha == null) {
-            throw ExceptionWithMessage("验证码未填写");
-          }
-          _captcha = captcha.trim();
-          continue;
-        }
-
-        if (responseText == "null") return Tuple(null, []);
-        var timetableJson = RegExp('(?<="kbList":)\\[(.*?)\\](?=,"xh")')
+        var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
             .firstMatch(responseText)
             ?.group(0);
-        if (timetableJson == null) throw ExceptionWithMessage("无法解析课表");
-        var sessions = (jsonDecode(timetableJson) as List<dynamic>)
-            .where((e) =>
-                e['kcb'] != null &&
-                (e['sfyjskc'] != "1"))
-            .map((e) => Session.fromZdbk(e));
-        _db?.setCachedWebPage('zdbk_Timetable$year$semester', timetableJson);
-        return Tuple(null, sessions);
+        if (transcriptJson == null) throw ExceptionWithMessage("无法解析主修成绩");
+
+        var grades = (jsonDecode(transcriptJson) as List<dynamic>)
+            .where((e) => e['xkkh'] != null)
+            .map((e) {
+          var grade = Grade(e);
+          grade.major = true;
+          return grade;
+        });
+        var majorGpa = GpaHelper.calculateGpa(grades);
+        _db?.setCachedWebPage('zdbk_MajorGrade', transcriptJson);
+        return Tuple(
+            null, Tuple([majorGpa.item1[0], majorGpa.item2], responseText));
+      } catch (e) {
+        if (e is SessionExpiredException) rethrow;
+        var exception =
+            e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+        var cachedJson = _db?.getCachedWebPage('zdbk_MajorGrade') ?? '[]';
+        var grades = (jsonDecode(cachedJson) as List<dynamic>)
+            .where((e) => e['xkkh'] != null)
+            .map((e) {
+          var grade = Grade(e);
+          grade.major = true;
+          return grade;
+        });
+        var majorGpa = GpaHelper.calculateGpa(grades);
+        return Tuple(
+            exception,
+            Tuple([majorGpa.item1[0], majorGpa.item2],
+                '{"items":$cachedJson,"limit":0}'));
       }
-      throw ExceptionWithMessage("验证码识别失败");
-    } catch (e) {
-      if (e is SessionExpiredException) rethrow;
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      return Tuple(
-          exception,
-          (jsonDecode((_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
-                  '[]')) as List<dynamic>)
-              .where((e) =>
-                  e['kcb'] != null &&
-                  (e['sfyjskc'] != "1"))
-              .map((e) => Session.fromZdbk(e)));
-    }
+    });
+  }
+
+  Future<Tuple<Exception?, Iterable<Grade>>> getTranscript(
+      HttpClient httpClient) async {
+    return await _withAutoRelogin(httpClient, () async {
+      late HttpClientRequest request;
+      late HttpClientResponse response;
+
+      try {
+        request = await httpClient
+            .postUrl(Uri.parse(
+                "https://zdbk.zju.edu.cn/jwglxt/cxdy/xscjcx_cxXscjIndex.html?doType=query&queryModel.showCount=5000"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("请求超时"));
+        request.headers
+          ..add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html")
+          ..set('Connection', 'close')
+          ..add(
+              'User-Agent',
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+          ..add('Accept', 'application/json, text/javascript, */*; q=0.01')
+          ..add('X-Requested-With', 'XMLHttpRequest');
+        request.cookies.add(_jSessionId!);
+        request.cookies.add(_route!);
+        request.followRedirects = false;
+        response = await request.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("请求超时"));
+
+        var responseText = await response.transform(utf8.decoder).join();
+        _checkSessionExpired(response, responseText);
+
+        var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
+            .firstMatch(responseText)
+            ?.group(0);
+        if (transcriptJson == null) throw ExceptionWithMessage("无法解析成绩");
+
+        var grades = (jsonDecode(transcriptJson) as List<dynamic>)
+            .where((e) => e['xkkh'] != null)
+            .map((e) => Grade(e));
+        _db?.setCachedWebPage('zdbk_Transcript', transcriptJson);
+        return Tuple(null, grades);
+      } catch (e) {
+        if (e is SessionExpiredException) rethrow;
+        var exception =
+            e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+        return Tuple(
+            exception,
+            (jsonDecode((_db?.getCachedWebPage('zdbk_Transcript') ?? '[]'))
+                    as List<dynamic>)
+                .where((e) => e['xkkh'] != null)
+                .map((e) => Grade(e)));
+      }
+    });
+  }
+
+  Future<Tuple<Exception?, Iterable<Session>>> getTimetable(HttpClient httpClient, String year, String semester) async {
+    return await _withAutoRelogin(httpClient, () async {
+      late HttpClientRequest request;
+      late HttpClientResponse response;
+
+      try {
+        for (var i = 0; i < 3; i++) {
+          request = await httpClient
+              .postUrl(Uri.parse(
+                  "https://zdbk.zju.edu.cn/jwglxt/kbcx/xskbcx_cxXsKb.html"))
+              .timeout(const Duration(seconds: 8),
+                  onTimeout: () => throw ExceptionWithMessage("请求超时"));
+          request.headers
+            ..add("Referer",
+                "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html")
+            ..set('Connection', 'close')
+            ..add(
+                'User-Agent',
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+            ..add('Accept', 'application/json, text/javascript, */*; q=0.01')
+            ..add('X-Requested-With', 'XMLHttpRequest');
+          request.cookies.add(_jSessionId!);
+          request.cookies.add(_route!);
+          request.headers.contentType =
+              ContentType('application', 'x-www-form-urlencoded',
+                  charset: 'utf-8');
+          request.add(
+              utf8.encode('xnm=$year&xqm=$semester&captcha_value=$_captcha'));
+          response = await request.close().timeout(const Duration(seconds: 8),
+              onTimeout: () => throw ExceptionWithMessage("请求超时"));
+
+          var responseText = await response.transform(utf8.decoder).join();
+          _checkSessionExpired(response, responseText);
+
+          if (responseText.contains("captcha_error")) {
+            _captcha = null;
+            if (GlobalStatus.isFirstScreenReq) {
+              throw ExceptionWithMessage("需要验证码");
+            }
+            var imageBytes = await getCaptcha(httpClient);
+            var captcha = await ImageCodePortal.show(
+                imageBytes: imageBytes,
+                onRefresh: () async {
+                  return await getCaptcha(httpClient);
+                });
+            if (captcha == null) {
+              throw ExceptionWithMessage("验证码未填写");
+            }
+            _captcha = captcha.trim();
+            continue;
+          }
+
+          if (responseText == "null") return Tuple(null, []);
+          var timetableJson = RegExp('(?<="kbList":)\\[(.*?)\\](?=,"xh")')
+              .firstMatch(responseText)
+              ?.group(0);
+          if (timetableJson == null) throw ExceptionWithMessage("无法解析课表");
+          var sessions = (jsonDecode(timetableJson) as List<dynamic>)
+              .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
+              .map((e) => Session.fromZdbk(e));
+          _db?.setCachedWebPage('zdbk_Timetable$year$semester', timetableJson);
+          return Tuple(null, sessions);
+        }
+        throw ExceptionWithMessage("验证码识别失败");
+      } catch (e) {
+        if (e is SessionExpiredException) rethrow;
+        var exception =
+            e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+        return Tuple(
+            exception,
+            (jsonDecode((_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
+                    '[]')) as List<dynamic>)
+                .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
+                .map((e) => Session.fromZdbk(e)));
+      }
+    });
   }
 
   Future<Tuple<Exception?, Iterable<ExamDto>>> getExamsDto(
       HttpClient httpClient) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
+    return await _withAutoRelogin(httpClient, () async {
+      late HttpClientRequest request;
+      late HttpClientResponse response;
 
-    try {
-      if (_jSessionId == null || _route == null) {
-        throw SessionExpiredException();
+      try {
+        request = await httpClient
+            .postUrl(Uri.parse(
+                "https://zdbk.zju.edu.cn/jwglxt/xskscx/kscx_cxXsgrksIndex.html?doType=query&queryModel.showCount=5000"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("请求超时"));
+        request.headers
+          ..add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html")
+          ..set('Connection', 'close')
+          ..add(
+              'User-Agent',
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+          ..add('Accept', 'application/json, text/javascript, */*; q=0.01')
+          ..add('X-Requested-With', 'XMLHttpRequest');
+        request.cookies.add(_jSessionId!);
+        request.cookies.add(_route!);
+        request.followRedirects = false;
+        response = await request.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("请求超时"));
+
+        var responseText = await response.transform(utf8.decoder).join();
+        _checkSessionExpired(response, responseText);
+
+        var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
+            .firstMatch(responseText)
+            ?.group(0);
+        if (transcriptJson == null) throw ExceptionWithMessage("无法解析考试信息");
+
+        var exams = (jsonDecode(transcriptJson) as List<dynamic>)
+            .where((e) => e['xkkh'] != null)
+            .map((e) => ExamDto.fromZdbk(e));
+        _db?.setCachedWebPage('zdbk_exams', transcriptJson);
+        return Tuple(null, exams);
+      } catch (e) {
+        if (e is SessionExpiredException) rethrow;
+        var exception =
+            e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+        return Tuple(
+            exception,
+            (jsonDecode((_db?.getCachedWebPage('zdbk_exams') ?? '[]'))
+                    as List<dynamic>)
+                .where((e) => e['xkkh'] != null)
+                .map((e) => ExamDto.fromZdbk(e)));
       }
-      request = await httpClient
-          .postUrl(Uri.parse(
-              "https://zdbk.zju.edu.cn/jwglxt/xskscx/kscx_cxXsgrksIndex.html?doType=query&queryModel.showCount=5000"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-      // 【关键修改】添加 Referer
-      request.headers.add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html");
-      request.cookies.add(_jSessionId!);
-      request.cookies.add(_route!);
-      request.followRedirects = false;
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
-
-      var responseText = await response.transform(utf8.decoder).join();
-      _checkSessionExpired(response, responseText);
-
-      var transcriptJson = RegExp('(?<="items":)\\[(.*?)\\](?=,"limit")')
-          .firstMatch(responseText)
-          ?.group(0);
-      if (transcriptJson == null) throw ExceptionWithMessage("无法解析考试信息");
-
-      var exams = (jsonDecode(transcriptJson) as List<dynamic>)
-          .where((e) => e['xkkh'] != null)
-          .map((e) => ExamDto.fromZdbk(e));
-      _db?.setCachedWebPage('zdbk_exams', transcriptJson);
-      return Tuple(null, exams);
-    } catch (e) {
-      if (e is SessionExpiredException) rethrow;
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      return Tuple(
-          exception,
-          (jsonDecode((_db?.getCachedWebPage('zdbk_exams') ?? '[]'))
-                  as List<dynamic>)
-              .where((e) => e['xkkh'] != null)
-              .map((e) => ExamDto.fromZdbk(e)));
-    }
+    });
   }
 
   Future<Tuple<Exception?, Map<String, double>>> getPracticeScores(
       HttpClient httpClient, String studentId) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
+    return await _withAutoRelogin(httpClient, () async {
+      late HttpClientRequest request;
+      late HttpClientResponse response;
 
-    try {
-      if (_jSessionId == null || _route == null) {
-        throw SessionExpiredException();
-      }
-      request = await httpClient
-          .getUrl(Uri.parse(
-              "https://zdbk.zju.edu.cn/jwglxt/dessktgl/dessktcx_cxDessktcxIndex.html?gnmkdm=N108001&layout=default&su=$studentId"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-      // 【关键修改】添加 Referer
-      request.headers.add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html");
-      request.cookies.add(_jSessionId!);
-      request.cookies.add(_route!);
-      request.followRedirects = false;
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
+      try {
+        request = await httpClient
+            .getUrl(Uri.parse(
+                "https://zdbk.zju.edu.cn/jwglxt/dessktgl/dessktcx_cxDessktcxIndex.html?gnmkdm=N108001&layout=default&su=$studentId"))
+            .timeout(const Duration(seconds: 8),
+                onTimeout: () => throw ExceptionWithMessage("请求超时"));
+        request.headers
+          ..add("Referer", "https://zdbk.zju.edu.cn/jwglxt/xtgl/index_initMenu.html")
+          ..set('Connection', 'close')
+          ..add(
+              'User-Agent',
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36')
+          ..add('Accept',
+              'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8');
+        request.cookies.add(_jSessionId!);
+        request.cookies.add(_route!);
+        request.followRedirects = false;
+        response = await request.close().timeout(const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("请求超时"));
 
-      var html = await response.transform(utf8.decoder).join();
-      _checkSessionExpired(response, html);
+        var html = await response.transform(utf8.decoder).join();
+        _checkSessionExpired(response, html);
 
-      _db?.setCachedWebPage("zdbk_practiceScores", html);
+        _db?.setCachedWebPage("zdbk_practiceScores", html);
 
-      var scores = <String, double>{
-        'pt2': 0.0,
-        'pt3': 0.0,
-        'pt4': 0.0,
-      };
+        var scores = <String, double>{
+          'pt2': 0.0,
+          'pt3': 0.0,
+          'pt4': 0.0,
+        };
 
-      var rowPattern = RegExp(
-          r'<tr>.*?<td[^>]*>.*?</td>.*?<td[^>]*>(.*?)</td>.*?<td[^>]*>(.*?)</td>.*?</tr>',
-          dotAll: true);
-      var matches = rowPattern.allMatches(html);
-
-      for (var match in matches) {
-        var type = match.group(1)?.trim();
-        var scoreStr = match.group(2)?.trim();
-        if (type == null || scoreStr == null) continue;
-
-        double? score;
-        try {
-          score = double.tryParse(scoreStr);
-        } catch (_) {
-          continue;
-        }
-        if (score == null) continue;
-
-        if (type.contains('第二课堂')) {
-          scores['pt2'] = score;
-        } else if (type.contains('第三课堂')) {
-          scores['pt3'] = score;
-        } else if (type.contains('第四课堂')) {
-          scores['pt4'] = score;
-        }
-      }
-
-      if (scores['pt2'] == 0.0 &&
-          scores['pt3'] == 0.0 &&
-          scores['pt4'] == 0.0) {
-        var altPattern = RegExp(r'<td[^>]*>第二课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
+        var rowPattern = RegExp(
+            r'<tr>.*?<td[^>]*>.*?</td>.*?<td[^>]*>(.*?)</td>.*?<td[^>]*>(.*?)</td>.*?</tr>',
             dotAll: true);
-        var pt2Match = altPattern.firstMatch(html);
-        if (pt2Match != null) {
-          scores['pt2'] = double.tryParse(pt2Match.group(1) ?? '0') ?? 0.0;
+        var matches = rowPattern.allMatches(html);
+
+        for (var match in matches) {
+          var type = match.group(1)?.trim();
+          var scoreStr = match.group(2)?.trim();
+          if (type == null || scoreStr == null) continue;
+
+          double? score;
+          try {
+            score = double.tryParse(scoreStr);
+          } catch (_) {
+            continue;
+          }
+          if (score == null) continue;
+
+          if (type.contains('第二课堂')) {
+            scores['pt2'] = score;
+          } else if (type.contains('第三课堂')) {
+            scores['pt3'] = score;
+          } else if (type.contains('第四课堂')) {
+            scores['pt4'] = score;
+          }
         }
 
-        altPattern = RegExp(r'<td[^>]*>第三课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
-            dotAll: true);
-        var pt3Match = altPattern.firstMatch(html);
-        if (pt3Match != null) {
-          scores['pt3'] = double.tryParse(pt3Match.group(1) ?? '0') ?? 0.0;
-        }
-
-        altPattern = RegExp(r'<td[^>]*>第四课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
-            dotAll: true);
-        var pt4Match = altPattern.firstMatch(html);
-        if (pt4Match != null) {
-          scores['pt4'] = double.tryParse(pt4Match.group(1) ?? '0') ?? 0.0;
-        }
-      }
-
-      return Tuple(null, scores);
-    } catch (e) {
-      if (e is SessionExpiredException) rethrow;
-
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      
-      var cachedHtml = _db?.getCachedWebPage("zdbk_practiceScores");
-      if (cachedHtml != null) {
-        try {
-          var scores = <String, double>{
-            'pt2': 0.0,
-            'pt3': 0.0,
-            'pt4': 0.0,
-          };
+        if (scores['pt2'] == 0.0 && scores['pt3'] == 0.0 && scores['pt4'] == 0.0) {
           var altPattern = RegExp(
-              r'<td[^>]*>第二课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
-              dotAll: true);
-          var pt2Match = altPattern.firstMatch(cachedHtml);
+              r'<td[^>]*>第二课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+          var pt2Match = altPattern.firstMatch(html);
           if (pt2Match != null) {
             scores['pt2'] = double.tryParse(pt2Match.group(1) ?? '0') ?? 0.0;
           }
 
-          altPattern = RegExp(r'<td[^>]*>第三课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
-              dotAll: true);
-          var pt3Match = altPattern.firstMatch(cachedHtml);
+          altPattern = RegExp(
+              r'<td[^>]*>第三课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+          var pt3Match = altPattern.firstMatch(html);
           if (pt3Match != null) {
             scores['pt3'] = double.tryParse(pt3Match.group(1) ?? '0') ?? 0.0;
           }
 
-          altPattern = RegExp(r'<td[^>]*>第四课堂</td>.*?<td[^>]*>([0-9.]+)</td>',
-              dotAll: true);
-          var pt4Match = altPattern.firstMatch(cachedHtml);
+          altPattern = RegExp(
+              r'<td[^>]*>第四课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+          var pt4Match = altPattern.firstMatch(html);
           if (pt4Match != null) {
             scores['pt4'] = double.tryParse(pt4Match.group(1) ?? '0') ?? 0.0;
           }
-          return Tuple(exception, scores);
-        } catch (_) {}
+        }
+
+        return Tuple(null, scores);
+      } catch (e) {
+        if (e is SessionExpiredException) rethrow;
+
+        var exception =
+            e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+
+        var cachedHtml = _db?.getCachedWebPage("zdbk_practiceScores");
+        if (cachedHtml != null) {
+          try {
+            var scores = <String, double>{
+              'pt2': 0.0,
+              'pt3': 0.0,
+              'pt4': 0.0,
+            };
+            var altPattern = RegExp(
+                r'<td[^>]*>第二课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+            var pt2Match = altPattern.firstMatch(cachedHtml);
+            if (pt2Match != null) {
+              scores['pt2'] = double.tryParse(pt2Match.group(1) ?? '0') ?? 0.0;
+            }
+
+            altPattern = RegExp(
+                r'<td[^>]*>第三课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+            var pt3Match = altPattern.firstMatch(cachedHtml);
+            if (pt3Match != null) {
+              scores['pt3'] = double.tryParse(pt3Match.group(1) ?? '0') ?? 0.0;
+            }
+
+            altPattern = RegExp(
+                r'<td[^>]*>第四课堂</td>.*?<td[^>]*>([0-9.]+)</td>', dotAll: true);
+            var pt4Match = altPattern.firstMatch(cachedHtml);
+            if (pt4Match != null) {
+              scores['pt4'] = double.tryParse(pt4Match.group(1) ?? '0') ?? 0.0;
+            }
+            return Tuple(exception, scores);
+          } catch (_) {}
+        }
+        return Tuple(exception, {'pt2': 0.0, 'pt3': 0.0, 'pt4': 0.0});
       }
-      return Tuple(exception, {'pt2': 0.0, 'pt3': 0.0, 'pt4': 0.0});
-    }
+    });
   }
 
   Future<Uint8List> getCaptcha(HttpClient httpClient) async {

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,6 @@ import app_links
 import device_info_plus
 import flutter_local_notifications
 import flutter_secure_storage_macos
-import path_provider_foundation
 import share_plus
 import url_launcher_macos
 
@@ -18,7 +17,6 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }


### PR DESCRIPTION
## 写在最前面
celechron在学校教务网添加了一次验证码之后经常出现解析失败，我深受其扰，忍无可忍之下让Gemini 3 pro分析了一下问题可能所在并让它帮忙修复，最后测试结果是 **很成功** 的，多次长时间后的刷新都没有再出现解析失败白屏的现象。
十分希望您们可以考虑采纳这个pull request，或者参考一下Gemini以及Claude opus 4.6的分析进行维护。由于本人水平实在有限，为了防止我的表述不明白，让Gemini给了一份对比总结放在下面

---

# fix(http): 完善教务网会话过期检测与高并发自动重试机制
*(fix(http): improve session expiration detection and concurrent retry mechanism for Zdbk)*

## 发现的问题
在原有逻辑中，当用户长时间未操作 App，再次触发首页或课表刷新时，会极大概率导致刷新失败，并伴随以下异常：
1. `无法解析课表` / `无法解析成绩` 等正则解析错误。
2. 作业模块报错 `type 'Null' is not a subtype of type 'List<dynamic>' in type cast`。

只有用户重新登录才能恢复正常获取数据。

## 问题根本原因分析
对比原代码，导致上述问题的原因主要有以下几点：
1. **会话过期的误判**：原 `Zdbk` 类中没有对 HTTP 302 重定向或包含“统一身份认证”的登录页 HTML 进行拦截。当 Cookie 过期时，教务网返回登录页，原代码直接对其执行 JSON 正则匹配，导致匹配失败并抛出 `无法解析` 异常。
2. **缺乏请求级别的异常重试**：原 `UgrsSpider` 仅在 `getEverything` 开始前检查了一次 `_lastUpdateTime > 15` 分钟，而在具体请求抛出异常（如未登录、超时）时，直接将错误返回给 UI，缺乏自动重新获取 Cookie 并重试的闭环逻辑。
3. **底层异常被 Tuple 私吞**：原 `Zdbk` 类为了保证容错，将部分网络异常（如 SocketException）放入 `Tuple.item1` 中返回。外部调用者未对 `item1` 进行阻断性检查，导致真正的网络死连接或超时错误变成了静默失败。
4. **并发刷新时的 HttpClient 冲突**：当多个接口（课表、成绩、考试等）并发请求时，若其中一个接口发现失效并触发了重登操作（重建/关闭了 `_httpClient`），会导致其他正在进行中的并发请求被强行掐断，从而抛出 `Connection closed` 错误。

## 关键修改点

### 1. 增强 `Zdbk` 的底层防护 (`lib/http/zjuServices/zdbk.dart`)
* **新增会话过期检查**：引入 `_checkSessionExpired` 方法。在读取响应内容前，优先检查 `response.statusCode`（拦截 301/302 跳转）以及 `responseText`（拦截 CAS 登录特征），精准抛出 `SessionExpiredException`，而不再是模糊的“无法解析”。
* **补充 Header 防护**：在所有数据获取接口的 Request 中补充了 `Referer` 头，防止部分教务网接口因重定向丢失来源而触发 CSRF 拦截。
* **状态清理**：在 `login()` 方法触发时主动置空 `_captcha`，防止携带旧会话的验证码导致验证失败。

### 2. 重构 `UgrsSpider` 的网络重试调度 (`lib/http/ugrs_spider.dart`)
* **引入 `_fetchWithRetry` 智能重试循环**：将原先松散的 Future 请求用带有 `maxRetries` 的 wrapper 包装。当捕获到会话过期、解析失败、超时等异常时，自动挂起当前请求，触发 `login()` 后再重试。
* **拆箱 Tuple 隐藏异常 (Unboxing Tuple Errors)**：在 `_fetchWithRetry` 中增加了对 `Tuple.item1` 的主动嗅探。一旦发现底层被强行包装的 `Connection closed`、`超时` 等错误，强制抛出以激活重试机制。
* **HttpClient 生命周期与并发隔离**：
  * 在 `_doLogin()` 时，显式关闭旧的 `_httpClient` 并重新初始化，彻底清除脏 Cookie。
  * 在触发自动重试时，加入 `Future.delayed(Duration(milliseconds: 1000))`。这一秒的缓冲完美解决了由于强杀 HttpClient 导致的并发请求 `Connection closed` 问题，让被掐断的请求在获得新连接后再安全重试。
* **作业查询安全包裹**：对 `_courses.getTodo` 同样加上了重试 Wrapper，避免 Cookie 失效返回 Null 时直接引发类型强转崩溃。

## 测试情况
- 长时间挂机测试：多次静置超过 2 小时后点击刷新，**成功** 获取到成绩、课表等数据