### PR TITLE
feat: DDL截止提醒通知 & 修复课表同步失败白屏

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -67,6 +67,7 @@ class DatabaseHelper {
   final String kAllowTime = 'allowTime';
   final String kGpaStrategy = 'gpaStrategy';
   final String kPushOnGradeChange = 'pushOnGradeChange';
+  final String kPushOnDdlReminder = 'pushOnDdlReminder';
   final String kBrightnessMode = 'brightnessMode';
   final String kCourseIdMappingList = 'courseIdMappingList';
   final String kHideHomeGpa = 'hideHomeGpa';
@@ -78,6 +79,7 @@ class DatabaseHelper {
       allowTime: getAllowTime().obs,
       gpaStrategy: getGpaStrategy().obs,
       pushOnGradeChange: getPushOnGradeChange().obs,
+      pushOnDdlReminder: getPushOnDdlReminder().obs,
       brightnessMode: getBrightnessMode().obs,
       courseIdMappingList: getCourseIdMappingList().obs,
       hideHomeGpa: getHideHomeGpa().obs,
@@ -140,6 +142,17 @@ class DatabaseHelper {
 
   Future<void> setPushOnGradeChange(bool pushOnGradeChange) async {
     await optionsBox.put(kPushOnGradeChange, pushOnGradeChange);
+  }
+
+  bool getPushOnDdlReminder() {
+    if (optionsBox.get(kPushOnDdlReminder) == null) {
+      optionsBox.put(kPushOnDdlReminder, true);
+    }
+    return optionsBox.get(kPushOnDdlReminder);
+  }
+
+  Future<void> setPushOnDdlReminder(bool pushOnDdlReminder) async {
+    await optionsBox.put(kPushOnDdlReminder, pushOnDdlReminder);
   }
 
   Future<void> setBrightnessMode(BrightnessMode brightness) async {

--- a/lib/http/github_service.dart
+++ b/lib/http/github_service.dart
@@ -14,6 +14,7 @@ class GitHubService {
     'FoggyDawn',
     'poormonitor',
     'heddxh',
+    'ChenyuHeee',
   ];
 
   Future<Tuple<Exception?, List<String>>> getContributors(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,11 +37,17 @@ void main() async {
 
   var scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
   if (scholar.value.isLogan) {
+    // 启动时先用缓存数据展示，后台异步刷新
+    scholar.refresh();
     scholar.value.login().then((value) async {
       GlobalStatus.isFirstScreenReq = true;
       await scholar.value.refresh();
       GlobalStatus.isFirstScreenReq = false;
-    }).then((value) => scholar.refresh());
+    }).then((value) => scholar.refresh()).catchError((e) {
+      // 网络异常时保留本地缓存数据，不影响已有展示
+      GlobalStatus.isFirstScreenReq = false;
+      scholar.refresh();
+    });
   }
 
   ECardWidgetMessenger.update();

--- a/lib/model/option.dart
+++ b/lib/model/option.dart
@@ -28,6 +28,7 @@ class Option {
   RxMap<DateTime, DateTime> allowTime;
   Rx<GpaStrategy> gpaStrategy;
   RxBool pushOnGradeChange;
+  RxBool pushOnDdlReminder;
   Rx<BrightnessMode> brightnessMode;
   RxList<CourseIdMap> courseIdMappingList;
   RxBool hideHomeGpa;
@@ -38,6 +39,7 @@ class Option {
     required this.allowTime,
     required this.gpaStrategy,
     required this.pushOnGradeChange,
+    required this.pushOnDdlReminder,
     required this.brightnessMode,
     required this.courseIdMappingList,
     required this.hideHomeGpa,

--- a/lib/model/scholar.dart
+++ b/lib/model/scholar.dart
@@ -159,6 +159,7 @@ class Scholar {
       return [];
     }
     _mutex++;
+    try {
     return await _spider?.getEverything().then((value) async {
           for (var e in value.item1) {
             // ignore: avoid_print
@@ -248,8 +249,16 @@ class Scholar {
           return value.item1.every((e) => e == null)
               ? value.item2
               : value.item1;
-        }).whenComplete(() => _mutex--) ??
+        }) ??
         ['未登录'];
+    } catch (e) {
+      // 网络异常等情况下保留已有数据，不清空
+      // ignore: avoid_print
+      print('refresh error: $e');
+      return ['网络连接失败，请检查网络后重试'];
+    } finally {
+      _mutex--;
+    }
   }
 
   void updateLastUpdateTime(List<String?> errorMessage) {

--- a/lib/page/option/option_controller.dart
+++ b/lib/page/option/option_controller.dart
@@ -15,6 +15,8 @@ import 'package:celechron/utils/platform_features.dart';
 import 'package:celechron/model/calendar_to_system.dart';
 import 'package:celechron/model/calendar_to_ical.dart';
 
+import 'package:celechron/utils/utils.dart';
+
 class OptionController extends GetxController {
   final _option = Get.find<Option>(tag: 'option');
   final scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
@@ -31,7 +33,7 @@ class OptionController extends GetxController {
     _calendarManager = CalendarToSystemManager(scholar.value);
 
     if (PlatformFeatures.hasBackgroundRefresh) {
-      if (_option.pushOnGradeChange.value) {
+      if (_option.pushOnGradeChange.value || _option.pushOnDdlReminder.value) {
         Workmanager()
             .initialize(callbackDispatcher)
             .then((value) => Workmanager().registerPeriodicTask(
@@ -88,17 +90,44 @@ class OptionController extends GetxController {
   set pushOnGradeChange(bool value) {
     _option.pushOnGradeChange.value = value;
     _db.setPushOnGradeChange(value);
+    // 同步到 SecureStorage 供后台任务读取
+    _db.secureStorage.write(
+        key: 'pushOnGradeChange',
+        value: value.toString(),
+        iOptions: secureStorageIOSOptions);
 
     if (!PlatformFeatures.hasBackgroundRefresh) {
       return;
     }
 
+    _updateBackgroundWorker(value || pushOnDdlReminder);
+  }
+
+  bool get pushOnDdlReminder => _option.pushOnDdlReminder.value;
+
+  set pushOnDdlReminder(bool value) {
+    _option.pushOnDdlReminder.value = value;
+    _db.setPushOnDdlReminder(value);
+    // 同步到 SecureStorage 供后台任务读取
+    _db.secureStorage.write(
+        key: 'pushOnDdlReminder',
+        value: value.toString(),
+        iOptions: secureStorageIOSOptions);
+
+    if (!PlatformFeatures.hasBackgroundRefresh) {
+      return;
+    }
+
+    _updateBackgroundWorker(value || pushOnGradeChange);
+  }
+
+  void _updateBackgroundWorker(bool enabled) {
     Workmanager()
         .cancelByUniqueName('top.celechron.celechron.backgroundScholarFetch')
         .then((value) {
       if (Platform.isIOS) return Workmanager().printScheduledTasks();
     });
-    if (value) {
+    if (enabled) {
       FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
           FlutterLocalNotificationsPlugin();
       const initializationSettingsAndroid =

--- a/lib/page/option/option_view.dart
+++ b/lib/page/option/option_view.dart
@@ -66,12 +66,13 @@ class OptionPage extends StatelessWidget {
                     header: Container(
                         padding: const EdgeInsets.only(left: 16),
                         child: Text('教务', style: headerFooterTextStyle)),
-                    footer: _optionController.pushOnGradeChange &&
+                    footer: (_optionController.pushOnGradeChange ||
+                                _optionController.pushOnDdlReminder) &&
                             _optionController.scholar.value.isLogan
                         ? Padding(
                             padding: const EdgeInsets.only(left: 16),
                             child: Text(
-                                'Celechron 将不定期自动运行以刷新成绩。请开启通知权限，且不要将 Celechron 从后台中移除。',
+                                'Celechron 将不定期自动运行以刷新数据。请开启通知权限，且不要将 Celechron 从后台中移除。',
                                 style: headerFooterTextStyle))
                         : null,
                     children: <CupertinoListTile>[
@@ -158,6 +159,17 @@ class OptionPage extends StatelessWidget {
                               onChanged: PlatformFeatures.hasBackgroundRefresh
                                   ? (value) async {
                                       _optionController.pushOnGradeChange =
+                                          value;
+                                    }
+                                  : null,
+                            )),
+                        CupertinoListTile(
+                            title: const Text('推送作业截止提醒'),
+                            trailing: CupertinoSwitch(
+                              value: _optionController.pushOnDdlReminder,
+                              onChanged: PlatformFeatures.hasBackgroundRefresh
+                                  ? (value) async {
+                                      _optionController.pushOnDdlReminder =
                                           value;
                                     }
                                   : null,

--- a/lib/page/scholar/scholar_view.dart
+++ b/lib/page/scholar/scholar_view.dart
@@ -969,12 +969,40 @@ class ScholarPage extends StatelessWidget {
             } else {
               return SizedBox(
                   height: 500,
-                  child: Column(children: [
-                    const Spacer(),
-                    Text(_scholarController.scholar.isLogan ? '下拉刷新' : '未登录',
-                        style: CupertinoTheme.of(context).textTheme.textStyle),
-                    const Spacer()
-                  ]));
+                  child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Spacer(),
+                        Icon(
+                          _scholarController.scholar.isLogan
+                              ? CupertinoIcons.arrow_clockwise
+                              : CupertinoIcons.person_crop_circle,
+                          size: 48,
+                          color: CupertinoDynamicColor.resolve(
+                              CupertinoColors.secondaryLabel, context),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                            _scholarController.scholar.isLogan
+                                ? '下拉刷新以获取数据'
+                                : '未登录',
+                            style: CupertinoTheme.of(context)
+                                .textTheme
+                                .textStyle),
+                        if (_scholarController.scholar.isLogan)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8),
+                            child: Text(
+                              '离线数据将在同步失败时自动使用',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: CupertinoDynamicColor.resolve(
+                                    CupertinoColors.secondaryLabel, context),
+                              ),
+                            ),
+                          ),
+                        const Spacer()
+                      ]));
             }
           }),
         ),

--- a/lib/worker/background_app_refresh.dart
+++ b/lib/worker/background_app_refresh.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:celechron/model/scholar.dart';
 import 'package:workmanager/workmanager.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -33,24 +35,43 @@ Future<void> refreshScholar() async {
       android: initializationSettingsAndroid,
       iOS: initializationSettingsDarwin);
   await flutterLocalNotificationsPlugin.initialize(initializationSettings);
-  const androidNotificationDetails = AndroidNotificationDetails(
-    'top.celechron.celechron.gradeChange',
-    '成绩变动提醒',
-    importance: Importance.max,
-    priority: Priority.high,
-    showWhen: false,
+
+  // 成绩变动通知 channel
+  const gradeNotificationDetails = NotificationDetails(
+    android: AndroidNotificationDetails(
+      'top.celechron.celechron.gradeChange',
+      '成绩变动提醒',
+      importance: Importance.max,
+      priority: Priority.high,
+      showWhen: false,
+    ),
+    iOS: DarwinNotificationDetails(
+      presentSound: true,
+      presentBadge: true,
+      presentBanner: true,
+      presentList: true,
+      sound: 'default',
+      badgeNumber: 0,
+    ),
   );
-  const darwinNotificationDetails = DarwinNotificationDetails(
-    presentSound: true,
-    presentBadge: true,
-    presentBanner: true,
-    presentList: true,
-    sound: 'default',
-    badgeNumber: 0,
-  );
-  const notificationDetails = NotificationDetails(
-    android: androidNotificationDetails,
-    iOS: darwinNotificationDetails,
+
+  // DDL 截止提醒 channel
+  const ddlNotificationDetails = NotificationDetails(
+    android: AndroidNotificationDetails(
+      'top.celechron.celechron.ddlReminder',
+      '作业截止提醒',
+      importance: Importance.max,
+      priority: Priority.high,
+      showWhen: false,
+    ),
+    iOS: DarwinNotificationDetails(
+      presentSound: true,
+      presentBadge: true,
+      presentBanner: true,
+      presentList: true,
+      sound: 'default',
+      badgeNumber: 0,
+    ),
   );
 
   var scholar = Scholar();
@@ -67,6 +88,12 @@ Future<void> refreshScholar() async {
       '0';
   var pushOnGradeChangeFuse = await secureStorage.read(
       key: 'pushOnGradeChangeFuse', iOptions: secureStorageIOSOptions);
+  var pushOnGradeChange = await secureStorage.read(
+      key: 'pushOnGradeChange', iOptions: secureStorageIOSOptions);
+  var pushOnDdlReminder = await secureStorage.read(
+      key: 'pushOnDdlReminder', iOptions: secureStorageIOSOptions);
+  var notifiedDdlIdsStr = await secureStorage.read(
+      key: 'notifiedDdlIds', iOptions: secureStorageIOSOptions);
 
   try {
     var error = await scholar.login();
@@ -74,29 +101,77 @@ Future<void> refreshScholar() async {
     error = await scholar.refresh();
     if (error.any((e) => e != null)) return;
 
-    if (pushOnGradeChangeFuse == null) {
-      await flutterLocalNotificationsPlugin.show(
-          0,
-          '首次成绩推送',
-          '若有新出分的课程，Celechron 将会通知您。若不需要此功能，可在 Celechron 的设置页面中关闭。',
-          notificationDetails);
+    // 成绩变动通知
+    if (pushOnGradeChange != 'false') {
+      if (pushOnGradeChangeFuse == null) {
+        await flutterLocalNotificationsPlugin.show(
+            0,
+            '首次成绩推送',
+            '若有新出分的课程，Celechron 将会通知您。若不需要此功能，可在 Celechron 的设置页面中关闭。',
+            gradeNotificationDetails);
+        await secureStorage.write(
+            key: 'pushOnGradeChangeFuse',
+            value: '1',
+            iOptions: secureStorageIOSOptions);
+      } else if (scholar.gpa[0] != double.tryParse(oldGpa) ||
+          scholar.gradedCourseCount != int.tryParse(gradedCourseCount)) {
+        await flutterLocalNotificationsPlugin.show(0, '成绩变动提醒',
+            '有新出分的课程，可在 Celechron 的学业页面中刷新查看。', gradeNotificationDetails);
+      }
       await secureStorage.write(
-          key: 'pushOnGradeChangeFuse',
-          value: '1',
+          key: 'gpa',
+          value: scholar.gpa[0].toString(),
           iOptions: secureStorageIOSOptions);
-    } else if (scholar.gpa[0] != double.tryParse(oldGpa) ||
-        scholar.gradedCourseCount != int.tryParse(gradedCourseCount)) {
-      await flutterLocalNotificationsPlugin.show(
-          0, '成绩变动提醒', '有新出分的课程，可在 Celechron 的学业页面中刷新查看。', notificationDetails);
+      await secureStorage.write(
+          key: 'gradedCourseCount',
+          value: scholar.gradedCourseCount.toString(),
+          iOptions: secureStorageIOSOptions);
     }
-    await secureStorage.write(
-        key: 'gpa',
-        value: scholar.gpa[0].toString(),
-        iOptions: secureStorageIOSOptions);
-    await secureStorage.write(
-        key: 'gradedCourseCount',
-        value: scholar.gradedCourseCount.toString(),
-        iOptions: secureStorageIOSOptions);
+
+    // DDL 截止提醒
+    if (pushOnDdlReminder != 'false') {
+      Set<String> notifiedDdlIds = {};
+      if (notifiedDdlIdsStr != null && notifiedDdlIdsStr.isNotEmpty) {
+        notifiedDdlIds = Set<String>.from(jsonDecode(notifiedDdlIdsStr));
+      }
+
+      var now = DateTime.now();
+      var upcomingTodos = scholar.todos.where((todo) {
+        if (todo.endTime == null) return false;
+        var timeLeft = todo.endTime!.difference(now);
+        // 24 小时内到期且尚未通知过
+        return timeLeft.inHours >= 0 &&
+            timeLeft.inHours <= 24 &&
+            !notifiedDdlIds.contains(todo.id);
+      }).toList();
+
+      if (upcomingTodos.isNotEmpty) {
+        var notificationId = 1000; // DDL 通知从 1000 开始
+        for (var todo in upcomingTodos) {
+          var hoursLeft = todo.endTime!.difference(now).inHours;
+          var timeDesc = hoursLeft > 0 ? '$hoursLeft 小时后' : '即将';
+          await flutterLocalNotificationsPlugin.show(
+              notificationId++,
+              '作业截止提醒',
+              '「${todo.course}」的作业「${todo.name}」将于$timeDesc截止',
+              ddlNotificationDetails);
+          notifiedDdlIds.add(todo.id);
+        }
+      }
+
+      // 清理已过期的通知记录，避免无限增长
+      notifiedDdlIds.removeWhere((id) {
+        var todo = scholar.todos.where((t) => t.id == id);
+        if (todo.isEmpty) return true;
+        return todo.first.endTime != null &&
+            todo.first.endTime!.isBefore(now);
+      });
+
+      await secureStorage.write(
+          key: 'notifiedDdlIds',
+          value: jsonEncode(notifiedDdlIds.toList()),
+          iOptions: secureStorageIOSOptions);
+    }
   } catch (e) {
     return;
   }


### PR DESCRIPTION
- 新增DDL截止提醒: 后台每15分钟检测24小时内到期作业并推送通知
- 设置页新增「推送作业截止提醒」开关
- 修复同步失败时Scholar数据被清空的问题:
  - refresh()增加try-catch保护，异常时保留本地缓存
  - 启动时先展示离线缓存数据，后台异步刷新
  - 刷新失败不影响已有数据展示
- 改善空数据页面UX，显示操作提示和离线说明