### PR TITLE
刷新可靠性与性能综合改进：会话过期自动重试、异步刷新与进度反馈、主页跟手切页

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -71,6 +71,7 @@ class DatabaseHelper {
   final String kBrightnessMode = 'brightnessMode';
   final String kCourseIdMappingList = 'courseIdMappingList';
   final String kHideHomeGpa = 'hideHomeGpa';
+  final String kAsyncRefresh = 'asyncRefresh';
 
   Option getOption() {
     return Option(
@@ -83,6 +84,7 @@ class DatabaseHelper {
       brightnessMode: getBrightnessMode().obs,
       courseIdMappingList: getCourseIdMappingList().obs,
       hideHomeGpa: getHideHomeGpa().obs,
+      asyncRefresh: getAsyncRefresh().obs,
     );
   }
 
@@ -175,6 +177,18 @@ class DatabaseHelper {
 
   Future<void> setHideHomeGpa(bool hideHomeGpa) async {
     await optionsBox.put(kHideHomeGpa, hideHomeGpa);
+  }
+
+  // 异步刷新：数据边刷出边显示。默认关闭，即等全部刷完后一次性更新
+  bool getAsyncRefresh() {
+    if (optionsBox.get(kAsyncRefresh) == null) {
+      optionsBox.put(kAsyncRefresh, false);
+    }
+    return optionsBox.get(kAsyncRefresh);
+  }
+
+  Future<void> setAsyncRefresh(bool asyncRefresh) async {
+    await optionsBox.put(kAsyncRefresh, asyncRefresh);
   }
 
   List<CourseIdMap> getCourseIdMappingList() {

--- a/lib/design/refresh_status_indicator.dart
+++ b/lib/design/refresh_status_indicator.dart
@@ -23,8 +23,7 @@ class RefreshStatusIndicator extends StatefulWidget {
   final String? message;
 
   @override
-  State<RefreshStatusIndicator> createState() =>
-      _RefreshStatusIndicatorState();
+  State<RefreshStatusIndicator> createState() => _RefreshStatusIndicatorState();
 }
 
 class _RefreshStatusIndicatorState extends State<RefreshStatusIndicator> {

--- a/lib/design/refresh_status_indicator.dart
+++ b/lib/design/refresh_status_indicator.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/cupertino.dart';
+
+import 'rolling_shimmer_text.dart';
+
+/// 下拉刷新指示区内容：复刻 CupertinoSliverRefreshControl 默认 builder 的
+/// 各状态转圈（框架 cupertino/refresh.dart 的 buildRefreshIndicator），并在
+/// 转圈右侧附加滚动状态文案，转圈+文案作为整体水平居中。
+/// message 为 null 时输出与原生逐像素一致。
+class RefreshStatusIndicator extends StatefulWidget {
+  const RefreshStatusIndicator({
+    super.key,
+    required this.refreshState,
+    required this.pulledExtent,
+    required this.refreshTriggerPullDistance,
+    required this.refreshIndicatorExtent,
+    required this.message,
+  });
+
+  final RefreshIndicatorMode refreshState;
+  final double pulledExtent;
+  final double refreshTriggerPullDistance;
+  final double refreshIndicatorExtent;
+  final String? message;
+
+  @override
+  State<RefreshStatusIndicator> createState() =>
+      _RefreshStatusIndicatorState();
+}
+
+class _RefreshStatusIndicatorState extends State<RefreshStatusIndicator> {
+  // 与框架 _kActivityIndicatorRadius / _kActivityIndicatorMargin 一致
+  static const double _radius = 14.0;
+  static const double _margin = 16.0;
+
+  // 刷新结束时 message 会先被置空、随后才进入 done 收起动画，
+  // 缓存末条文案让文字随转圈一起淡出，而不是瞬间消失
+  String? _lastShown;
+
+  Widget _buildSpinner(double percentageComplete) {
+    switch (widget.refreshState) {
+      case RefreshIndicatorMode.drag:
+        const Curve opacityCurve = Interval(0.0, 0.35, curve: Curves.easeInOut);
+        return Opacity(
+          opacity: opacityCurve.transform(percentageComplete),
+          child: CupertinoActivityIndicator.partiallyRevealed(
+              radius: _radius, progress: percentageComplete),
+        );
+      case RefreshIndicatorMode.armed:
+      case RefreshIndicatorMode.refresh:
+        return const CupertinoActivityIndicator(radius: _radius);
+      case RefreshIndicatorMode.done:
+        return CupertinoActivityIndicator(radius: _radius * percentageComplete);
+      case RefreshIndicatorMode.inactive:
+        return const SizedBox.shrink();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final percentageComplete =
+        (widget.pulledExtent / widget.refreshTriggerPullDistance)
+            .clamp(0.0, 1.0)
+            .toDouble();
+
+    if (widget.refreshState == RefreshIndicatorMode.inactive ||
+        widget.refreshState == RefreshIndicatorMode.drag) {
+      // 新一轮下拉不残留上一轮文案
+      _lastShown = widget.message;
+    } else if (widget.message != null) {
+      _lastShown = widget.message;
+    }
+    final showText = _lastShown != null &&
+        (widget.refreshState == RefreshIndicatorMode.armed ||
+            widget.refreshState == RefreshIndicatorMode.refresh ||
+            widget.refreshState == RefreshIndicatorMode.done);
+    // done 阶段随 sliver 收起同步淡出。刷新驻留时 pulledExtent 恰为
+    // refreshIndicatorExtent，以其为分母，淡出起点正好是 1.0
+    final textOpacity = widget.refreshState == RefreshIndicatorMode.done
+        ? (widget.pulledExtent / widget.refreshIndicatorExtent)
+            .clamp(0.0, 1.0)
+            .toDouble()
+        : 1.0;
+
+    return Center(
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Positioned(
+            top: _margin,
+            left: 0.0,
+            right: 0.0,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // 固定转圈槽位，done 态转圈收缩时文案不横移
+                SizedBox(
+                  width: _radius * 2,
+                  height: _radius * 2,
+                  child: Center(child: _buildSpinner(percentageComplete)),
+                ),
+                Flexible(
+                  child: AnimatedSize(
+                    duration: const Duration(milliseconds: 250),
+                    curve: Curves.easeInOut,
+                    alignment: Alignment.centerLeft,
+                    child: showText
+                        ? Padding(
+                            padding: const EdgeInsets.only(left: 8),
+                            child: Opacity(
+                              opacity: textOpacity,
+                              child: RollingShimmerText(_lastShown!),
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/design/rolling_shimmer_text.dart
+++ b/lib/design/rolling_shimmer_text.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/cupertino.dart';
+
+/// 刷新状态文案：浅灰小字，换字时新字自下而上顶掉旧字，
+/// 字面周期性扫过一道白色流光（颜色作用于文字本身，而非背景）
+class RollingShimmerText extends StatefulWidget {
+  const RollingShimmerText(
+    this.text, {
+    super.key,
+    this.fontSize = 13,
+    this.shimmerPeriod = const Duration(milliseconds: 2500),
+  });
+
+  final String text;
+  final double fontSize;
+  final Duration shimmerPeriod;
+
+  @override
+  State<RollingShimmerText> createState() => _RollingShimmerTextState();
+}
+
+class _RollingShimmerTextState extends State<RollingShimmerText>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _shimmer;
+
+  @override
+  void initState() {
+    super.initState();
+    _shimmer = AnimationController(vsync: this, duration: widget.shimmerPeriod)
+      ..repeat();
+  }
+
+  @override
+  void dispose() {
+    _shimmer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 底色取与转圈同族的浅灰；流光为白色，深浅色模式下都比底色亮
+    final base =
+        CupertinoDynamicColor.resolve(CupertinoColors.secondaryLabel, context);
+    const highlight = Color(0xFFFFFFFF);
+    return RepaintBoundary(
+      child: AnimatedBuilder(
+        animation: _shimmer,
+        builder: (context, child) => ShaderMask(
+          blendMode: BlendMode.srcIn,
+          shaderCallback: (bounds) {
+            // 每个周期的前 45% 完成一次自左向右的扫掠，
+            // 其余时间高光带停在文字之外，字面保持纯底色
+            final t = (_shimmer.value / 0.45).clamp(0.0, 1.0);
+            final dx = bounds.width * (t * 3.0 - 1.5);
+            return LinearGradient(
+              colors: [base, highlight, base],
+              stops: const [0.35, 0.5, 0.65],
+            ).createShader(bounds.translate(dx, 0));
+          },
+          child: child,
+        ),
+        child: AnimatedSize(
+          duration: const Duration(milliseconds: 250),
+          curve: Curves.easeInOut,
+          alignment: Alignment.centerLeft,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 350),
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeInCubic,
+            // 此闭包必须内联：AnimatedSwitcher 只在 transitionBuilder 身份变化时
+            // 才为旧字重建过渡（见框架 AnimatedSwitcher.didUpdateWidget），每次
+            // build 产生新闭包恰好让旧字落入「从上方滑出」分支（其动画反向播放，
+            // 即 0 → (0,-1) 向上顶出）。不要提成 static 或顶层函数。
+            transitionBuilder: (child, animation) {
+              final incoming = child.key == ValueKey<String>(widget.text);
+              return ClipRect(
+                child: SlideTransition(
+                  position: Tween<Offset>(
+                    begin: incoming ? const Offset(0, 1) : const Offset(0, -1),
+                    end: Offset.zero,
+                  ).animate(animation),
+                  child: FadeTransition(opacity: animation, child: child),
+                ),
+              );
+            },
+            layoutBuilder: (currentChild, previousChildren) => Stack(
+              alignment: Alignment.centerLeft,
+              children: [
+                ...previousChildren,
+                if (currentChild != null) currentChild,
+              ],
+            ),
+            child: Text(
+              widget.text,
+              key: ValueKey<String>(widget.text),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              // srcIn 会用渐变整体替换字色，这里只需保证不透明
+              style: TextStyle(
+                fontSize: widget.fontSize,
+                color: const Color(0xFFFFFFFF),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:celechron/http/retry_helper.dart';
 import 'package:celechron/http/spider.dart';
 import 'package:celechron/http/time_config_service.dart';
 import 'package:celechron/http/zjuServices/courses.dart';
@@ -28,6 +29,10 @@ class GrsSpider implements Spider {
   Cookie? _iPlanetDirectoryPro;
   DateTime _lastUpdateTime = DateTime(0);
   Future<List<String?>>? _reloginFuture;
+  static const _retryableFetchErrors = <String>[
+    "iplanetdirectorypro无效",
+    "会话已过期",
+  ];
   static List<String> fetchSequenceGrs = [
     '配置',
     '课表',
@@ -51,6 +56,9 @@ class GrsSpider implements Spider {
 
   void _initHttpClient() {
     _httpClient = HttpClient();
+    // 建立连接（TCP/TLS握手）5秒内不成功视为网络不可用，快速失败；
+    // 已建立的连接传输慢则交给各请求自己的总超时兜底
+    _httpClient.connectionTimeout = const Duration(seconds: 5);
     _httpClient.userAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.1587.63";
   }
@@ -131,70 +139,41 @@ class GrsSpider implements Spider {
     _username = "";
     _password = "";
     _iPlanetDirectoryPro = null;
+    _reloginFuture = null;
     try {
       _httpClient.close(force: true);
     } catch (_) {}
     // _appService.logout();
+    _courses.logout();
     _zdbk.logout();
     _grsNew.logout();
   }
 
-  // ===== 新增开始 =====
-  // 自动重试机制：遇到Cookie过期等错误时，自动重新登录再重试
-  Future<T> _fetchWithRetry<T>(Future<T> Function() operation,
-      {int maxRetries = 2}) async {
+  Future<T> _fetchWithRetry<T>(
+    Future<T> Function() operation, {
+    int maxRetries = 1,
+  }) async {
     int attempts = 0;
     while (true) {
       try {
         var result = await operation();
+        final hiddenError = getRetryableTupleError(
+          result,
+          extraMessages: _retryableFetchErrors,
+        );
 
-        // 检查返回结果中是否隐藏了错误
-        bool hasHiddenError = false;
-        dynamic hiddenErrorToThrow;
-        try {
-          dynamic res = result;
-          if (res != null && res.item1 != null) {
-            String errStr = res.item1.toString().toLowerCase();
-            if (errStr.contains("connection closed") ||
-                errStr.contains("httpexception") ||
-                errStr.contains("请求超时") ||
-                errStr.contains("网络错误") ||
-                errStr.contains("未登录") ||
-                errStr.contains("超时") ||
-                errStr.contains("timeout") ||
-                errStr.contains("type 'null'") ||
-                errStr.contains("iplanetdirectorypro无效") ||
-                errStr.contains("会话已过期")) {
-              hasHiddenError = true;
-              hiddenErrorToThrow = res.item1;
-            }
-          }
-        } catch (_) {}
-
-        if (hasHiddenError) {
-          throw hiddenErrorToThrow;
+        if (hiddenError != null) {
+          throw hiddenError;
         }
 
         return result;
       } catch (e) {
         attempts++;
-        String errStr = e.toString().toLowerCase();
 
-        // 判断是否是可以通过重新登录解决的错误
         if (attempts <= maxRetries &&
-            (e is SessionExpiredException ||
-                errStr.contains("未登录") ||
-                errStr.contains("iplanetdirectorypro无效") ||
-                errStr.contains("会话已过期") ||
-                errStr.contains("connection closed") ||
-                errStr.contains("timeout") ||
-                errStr.contains("超时") ||
-                errStr.contains("请求超时") ||
-                errStr.contains("httpexception") ||
-                errStr.contains("网络错误") ||
-                errStr.contains("socketexception"))) {
-          await login(); // 重新获取 iPlanetDirectoryPro
-          await Future.delayed(const Duration(milliseconds: 1000));
+            shouldRetryAfterLogin(e, extraMessages: _retryableFetchErrors)) {
+          await login();
+          await Future.delayed(const Duration(milliseconds: 300));
           continue;
         }
 
@@ -202,7 +181,6 @@ class GrsSpider implements Spider {
       }
     }
   }
-  // ===== 新增结束 =====
 
   // 返回一堆错误信息，如果有的话。看看返回的List是不是空的就知道刷新是否成功。
   @override

--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -236,44 +236,36 @@ class GrsSpider implements Spider {
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-1').then((value) {
         if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-1']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          final config = jsonDecode(value.item2!);
+          outSemesters[semesterIndexMap['$yearStr-1']!].addZjuCalendar(config);
+          outSpecialDates.addAll((config['holiday'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(0, 8)),
+              '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(8, 16)),
+              '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+          outSpecialDates.addAll((config['dummy'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
         }
         return value.item1?.toString();
       }).catchError((e) => 'semesterConf($yearStr-1) $e'));
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-2').then((value) {
         if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-2']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          final config = jsonDecode(value.item2!);
+          outSemesters[semesterIndexMap['$yearStr-2']!].addZjuCalendar(config);
+          outSpecialDates.addAll((config['holiday'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(0, 8)),
+              '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(8, 16)),
+              '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+          outSpecialDates.addAll((config['dummy'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
         }
         return value.item1?.toString();
       }).catchError((e) => 'semesterConf($yearStr-2) $e'));

--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -184,15 +184,8 @@ class GrsSpider implements Spider {
 
   // 返回一堆错误信息，如果有的话。看看返回的List是不是空的就知道刷新是否成功。
   @override
-  Future<
-      Tuple7<
-          List<String?>,
-          List<String?>,
-          List<Semester>,
-          List<Grade>,
-          List<double>,
-          Map<DateTime, String>,
-          List<Todo>>> getEverything() async {
+  Future<EverythingTuple> getEverything(
+      {void Function(EverythingTuple partial)? onProgress}) async {
     // 返回值初始化
     var outSemesters = <Semester>[];
     var outGrades = <Grade>[];
@@ -451,6 +444,23 @@ class GrsSpider implements Spider {
       outTodos.addAll(value.item2);
       return value.item1?.toString();
     }).catchError((e) => 'coursesTodo $e'));
+
+    // 异步刷新：每完成一个顶层任务就向上层回调一次当前进度。
+    // 配置(0)、课表(1)、本科生课考试(2)、本科生课成绩(3)、研究生课考试(4)、
+    // 研究生课成绩(5)共同拼出学期数据，全部成功后才暴露学期
+    if (onProgress != null) {
+      attachEverythingProgress(
+          fetches: fetches,
+          fetchSequence: fetchSequenceGrs,
+          semesterFetchIndices: const [0, 1, 2, 3, 4, 5],
+          loginErrorMessages: loginErrorMessages,
+          semesters: outSemesters,
+          grades: outGrades,
+          majorGrade: outMajorGrade,
+          specialDates: outSpecialDates,
+          todos: outTodos,
+          onProgress: onProgress);
+    }
 
     // await一下，等待所有请求完成。然后，删除不包含考试、成绩、课程的空学期
     var fetchErrorMessages = await Future.wait(fetches).whenComplete(() {

--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -33,7 +33,8 @@ class GrsSpider implements Spider {
     "iplanetdirectorypro无效",
     "会话已过期",
   ];
-  static List<String> fetchSequenceGrs = [
+  /// getEverything 内各顶层抓取任务的标签，与抓取错误列表下标一一对应
+  static const List<String> fetchSequenceGrs = [
     '配置',
     '课表',
     '本科生课考试',
@@ -42,6 +43,9 @@ class GrsSpider implements Spider {
     '研究生课成绩',
     '作业'
   ];
+
+  @override
+  List<String> get fetchLabels => fetchSequenceGrs;
 
   GrsSpider(String username, String password) {
     _initHttpClient();

--- a/lib/http/grs_spider.dart
+++ b/lib/http/grs_spider.dart
@@ -33,6 +33,7 @@ class GrsSpider implements Spider {
     "iplanetdirectorypro无效",
     "会话已过期",
   ];
+
   /// getEverything 内各顶层抓取任务的标签，与抓取错误列表下标一一对应
   static const List<String> fetchSequenceGrs = [
     '配置',

--- a/lib/http/retry_helper.dart
+++ b/lib/http/retry_helper.dart
@@ -1,0 +1,41 @@
+import 'package:celechron/http/zjuServices/exceptions.dart';
+
+const _commonRetryableMessages = <String>[
+  "connection closed",
+  "httpexception",
+  "网络错误",
+  "未登录",
+  "超时",
+  "timeout",
+  "type 'null'",
+  "socketexception",
+  "无法获取session",
+  "会话已过期",
+];
+
+bool shouldRetryAfterLogin(
+  Object error, {
+  Iterable<String> extraMessages = const [],
+}) {
+  if (error is SessionExpiredException) return true;
+
+  final message = error.toString().toLowerCase();
+  return _commonRetryableMessages
+      .followedBy(extraMessages)
+      .any(message.contains);
+}
+
+Object? getRetryableTupleError(
+  Object? result, {
+  Iterable<String> extraMessages = const [],
+}) {
+  try {
+    final error = (result as dynamic)?.item1;
+    if (error == null) return null;
+    return shouldRetryAfterLogin(error, extraMessages: extraMessages)
+        ? error
+        : null;
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/http/spider.dart
+++ b/lib/http/spider.dart
@@ -9,6 +9,35 @@ import 'package:celechron/model/todo.dart';
 typedef EverythingTuple = Tuple7<List<String?>, List<String?>, List<Semester>,
     List<Grade>, List<double>, Map<DateTime, String>, List<Todo>>;
 
+/// 单个抓取模块的状态（供刷新状态文案使用）
+enum FetchModuleState { pending, success, failed }
+
+/// 一个顶层抓取模块的标签与当前状态
+class ModuleFetchStatus {
+  final String label;
+  final FetchModuleState state;
+
+  const ModuleFetchStatus(this.label, this.state);
+}
+
+/// 由 getEverything 的抓取错误列表（中间态或最终态）推导各模块状态。
+/// null=成功；以「查询进行中」结尾=进行中；其余=失败。
+/// 两表长度不等时视为不可信，返回空列表。
+List<ModuleFetchStatus> moduleStatusesFromErrors(
+    List<String?> errors, List<String> labels) {
+  if (errors.length != labels.length) return const [];
+  return List.generate(labels.length, (i) {
+    final e = errors[i];
+    return ModuleFetchStatus(
+        labels[i],
+        e == null
+            ? FetchModuleState.success
+            : e.endsWith('查询进行中')
+                ? FetchModuleState.pending
+                : FetchModuleState.failed);
+  });
+}
+
 abstract class Spider {
   set db(DatabaseHelper? db);
 
@@ -19,6 +48,9 @@ abstract class Spider {
   void logout() {
     throw UnimplementedError();
   }
+
+  /// 顶层抓取任务的标签序列，与 getEverything 返回值的抓取错误列表下标一一对应
+  List<String> get fetchLabels;
 
   /// onProgress：异步刷新用。每完成一个顶层抓取任务，就带着当前已累积的数据回调一次；
   /// 传 null 则行为与原来完全一致。

--- a/lib/http/spider.dart
+++ b/lib/http/spider.dart
@@ -5,6 +5,10 @@ import 'package:celechron/model/grade.dart';
 import 'package:celechron/model/semester.dart';
 import 'package:celechron/model/todo.dart';
 
+/// getEverything 的返回值：登录错误、抓取错误、学期、成绩、主修成绩、特殊日期、作业
+typedef EverythingTuple = Tuple7<List<String?>, List<String?>, List<Semester>,
+    List<Grade>, List<double>, Map<DateTime, String>, List<Todo>>;
+
 abstract class Spider {
   set db(DatabaseHelper? db);
 
@@ -16,15 +20,73 @@ abstract class Spider {
     throw UnimplementedError();
   }
 
-  Future<
-      Tuple7<
-          List<String?>,
-          List<String?>,
-          List<Semester>,
-          List<Grade>,
-          List<double>,
-          Map<DateTime, String>,
-          List<Todo>>> getEverything() async {
+  /// onProgress：异步刷新用。每完成一个顶层抓取任务，就带着当前已累积的数据回调一次；
+  /// 传 null 则行为与原来完全一致。
+  Future<EverythingTuple> getEverything(
+      {void Function(EverythingTuple partial)? onProgress}) async {
     throw UnimplementedError();
+  }
+}
+
+/// 异步刷新支持：给每个顶层抓取任务挂一个旁路监听，任一任务完成就把当前累积的
+/// 数据打包回调给上层，让界面先行更新。
+///
+/// 学期数据由多个任务共同拼装（校历/配置、课表、考试、成绩），必须等
+/// [semesterFetchIndices] 指定的任务全部成功后才对外暴露，否则不完整的学期列表
+/// 会顶掉本地缓存；特殊日期同理，须等校历/配置任务（下标 0）成功。
+/// 全部任务完成后的那一次不再回调，由 getEverything 的正常返回值做最终合并。
+void attachEverythingProgress({
+  required List<Future<String?>> fetches,
+  required List<String> fetchSequence,
+  required List<int> semesterFetchIndices,
+  required List<String?> loginErrorMessages,
+  required List<Semester> semesters,
+  required List<Grade> grades,
+  required List<double> majorGrade,
+  required Map<DateTime, String> specialDates,
+  required List<Todo> todos,
+  required void Function(EverythingTuple partial) onProgress,
+}) {
+  var errors = List<String?>.filled(fetches.length, null);
+  var done = List<bool>.filled(fetches.length, false);
+  for (var i = 0; i < fetches.length; i++) {
+    fetches[i].then((e) {
+      done[i] = true;
+      errors[i] = e == null ? null : '${fetchSequence[i]}查询出错：$e';
+      if (done.every((d) => d)) return;
+      // 下标 0 为校历/配置任务
+      var calendarReady = done[0] && errors[0] == null;
+      var semestersReady = calendarReady &&
+          semesterFetchIndices.every((j) => done[j] && errors[j] == null);
+      // 中间态错误列表：尚未完成的任务标记为“查询进行中”，与“成功（null）”区分开，
+      // 让 setScholar / updateLastUpdateTime 的关键字守卫把它们当作“尚未成功”，
+      // 只有已成功板块才合并数据、刷新“更新于”时间戳。最终返回值不带该标记。
+      var partialErrors = List<String?>.generate(fetches.length,
+          (j) => done[j] ? errors[j] : '${fetchSequence[j]}查询进行中');
+      // 学期数据由多个任务共同拼装，未就绪时课表一律视为进行中，
+      // 避免课表时间戳先于面板数据更新
+      if (!semestersReady) {
+        var timetableIndex = fetchSequence.indexOf('课表');
+        if (timetableIndex >= 0 && partialErrors[timetableIndex] == null) {
+          partialErrors[timetableIndex] = '课表查询进行中';
+        }
+      }
+      onProgress(Tuple7(
+          loginErrorMessages,
+          partialErrors,
+          semestersReady
+              ? semesters
+                  .where((e) =>
+                      e.grades.isNotEmpty ||
+                      e.sessions.isNotEmpty ||
+                      e.exams.isNotEmpty ||
+                      e.courses.isNotEmpty)
+                  .toList()
+              : <Semester>[],
+          grades,
+          majorGrade,
+          calendarReady ? specialDates : <DateTime, String>{},
+          todos));
+    });
   }
 }

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:celechron/http/retry_helper.dart';
 import 'package:celechron/http/zjuServices/courses.dart';
 import 'package:celechron/model/todo.dart';
 import 'package:get/get.dart';
@@ -30,6 +31,7 @@ class UgrsSpider implements Spider {
   bool _isPracticeScoresGet = false;
 
   Future<List<String?>>? _reloginFuture;
+  static const _retryableFetchErrors = <String>["无法解析", "iplanetdirectorypro无效"];
 
   UgrsSpider(String username, String password) {
     _initHttpClient(); // 初始化客户端移到单独方法
@@ -44,6 +46,9 @@ class UgrsSpider implements Spider {
   // 初始化或重置 HttpClient
   void _initHttpClient() {
     _httpClient = HttpClient();
+    // 建立连接（TCP/TLS握手）5秒内不成功视为网络不可用，快速失败；
+    // 已建立的连接传输慢则交给各请求自己的总超时兜底
+    _httpClient.connectionTimeout = const Duration(seconds: 5);
     _httpClient.userAgent =
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36 Edg/110.0.1587.63";
     // 强制不保存 Cookies，完全由 Zdbk 手动管理，避免冲突
@@ -73,11 +78,11 @@ class UgrsSpider implements Spider {
   }
 
   Future<List<String?>> _doLogin() async {
-    // 【关键修改】登录前先销毁旧的 HttpClient，防止旧 Cookie 或死连接干扰
     try {
       _httpClient.close(force: true);
     } catch (_) {}
-    _initHttpClient(); // 创建全新的客户端
+    _initHttpClient();
+    fetchGrs = false;
 
     var loginErrorMessages = <String?>[null];
     _iPlanetDirectoryPro =
@@ -122,6 +127,12 @@ class UgrsSpider implements Spider {
     _username = "";
     _password = "";
     _iPlanetDirectoryPro = null;
+    _reloginFuture = null;
+    try {
+      _httpClient.close(force: true);
+    } catch (_) {}
+    fetchGrs = false;
+    _courses.logout();
     _zdbk.logout();
     _grsNew.logout();
     _practiceScores = null;
@@ -131,67 +142,34 @@ class UgrsSpider implements Spider {
   Map<String, double>? get practiceScores => _practiceScores;
   bool get isPracticeScoresGet => _isPracticeScoresGet;
 
-  // 【终极修改】自带最大重试次数的循环重试机制，并正确拦截底层私吞的错误
-  Future<T> _fetchWithRetry<T>(Future<T> Function() operation,
-      {int maxRetries = 2}) async {
+  Future<T> _fetchWithRetry<T>(
+    Future<T> Function() operation, {
+    int maxRetries = 1,
+  }) async {
     int attempts = 0;
     while (true) {
       try {
-        var result = await operation(); // 尝试执行请求
+        var result = await operation();
+        final hiddenError = getRetryableTupleError(
+          result,
+          extraMessages: _retryableFetchErrors,
+        );
 
-        // 【修正】：将判断和抛出异常分开，防止抛出的异常被安全检查的 catch 吃掉
-        bool hasHiddenError = false;
-        dynamic hiddenErrorToThrow;
-
-        try {
-          dynamic res = result;
-          if (res != null && res.item1 != null) {
-            String errStr = res.item1.toString().toLowerCase();
-            if (errStr.contains("connection closed") ||
-                errStr.contains("httpexception") ||
-                errStr.contains("网络错误") ||
-                errStr.contains("未登录") ||
-                errStr.contains("超时") ||
-                errStr.contains("timeout") ||
-                errStr.contains("type 'null'") ||
-                errStr.contains("无法解析") ||
-                errStr.contains("wisportalid无效")) {
-              hasHiddenError = true;
-              hiddenErrorToThrow = res.item1;
-            }
-          }
-        } catch (_) {} // 这里只负责捕获 res.item1 的类型转换报错
-
-        // 如果发现了隐藏的错误，在 try-catch 外部将其抛出！
-        if (hasHiddenError) {
-          throw hiddenErrorToThrow;
+        if (hiddenError != null) {
+          throw hiddenError;
         }
 
-        return result; // 如果没有错误，正常返回
+        return result;
       } catch (e) {
         attempts++;
-        String errStr = e.toString().toLowerCase(); // 转小写方便匹配
 
-        // 判断是否符合重试条件（加入更全的关键字）
         if (attempts <= maxRetries &&
-            (e is SessionExpiredException ||
-                errStr.contains("未登录") ||
-                errStr.contains("wisportalid无效") ||
-                errStr.contains("无法解析") ||
-                errStr.contains("type 'null'") ||
-                errStr.contains("connection closed") ||
-                errStr.contains("timeout") ||
-                errStr.contains("超时") ||
-                errStr.contains("httpexception") ||
-                errStr.contains("网络错误") ||
-                errStr.contains("socketexception"))) {
-          // print("第 $attempts 次自动修复：检测到异常(${e.toString()})，正在重试...");
-          await login(); // 重建 HttpClient 并登录
-          await Future.delayed(const Duration(milliseconds: 1000)); // 给服务器1秒缓冲
-          continue; // 继续下一次尝试
+            shouldRetryAfterLogin(e, extraMessages: _retryableFetchErrors)) {
+          await login();
+          await Future.delayed(const Duration(milliseconds: 300));
+          continue;
         }
 
-        // 如果重试次数耗尽，或者是不认识的致命错误，才真正报错
         rethrow;
       }
     }

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -179,15 +179,8 @@ class UgrsSpider implements Spider {
   }
 
   @override
-  Future<
-      Tuple7<
-          List<String?>,
-          List<String?>,
-          List<Semester>,
-          List<Grade>,
-          List<double>,
-          Map<DateTime, String>,
-          List<Todo>>> getEverything() async {
+  Future<EverythingTuple> getEverything(
+      {void Function(EverythingTuple partial)? onProgress}) async {
     var fetches = <Future<String?>>[];
     List<String> fetchSequence = ['校历', '课表', '考试', '成绩', '主修', '作业', '实践'];
 
@@ -426,6 +419,22 @@ class UgrsSpider implements Spider {
       return e.toString();
     }));
 
+    // 异步刷新：每完成一个顶层任务就向上层回调一次当前进度。
+    // 校历(0)、课表(1)、考试(2)、成绩(3)共同拼出学期数据，全部成功后才暴露学期
+    if (onProgress != null) {
+      attachEverythingProgress(
+          fetches: fetches,
+          fetchSequence: fetchSequence,
+          semesterFetchIndices: const [0, 1, 2, 3],
+          loginErrorMessages: loginErrorMessages,
+          semesters: outSemesters,
+          grades: outGrades,
+          majorGrade: outMajorGrade,
+          specialDates: outSpecialDates,
+          todos: outTodos,
+          onProgress: onProgress);
+    }
+
     var fetchErrorMessages = await Future.wait(fetches).whenComplete(() {
       outSemesters.removeWhere((e) =>
           e.grades.isEmpty &&
@@ -479,15 +488,8 @@ class MockSpider extends UgrsSpider {
   void logout() {}
 
   @override
-  Future<
-      Tuple7<
-          List<String?>,
-          List<String?>,
-          List<Semester>,
-          List<Grade>,
-          List<double>,
-          Map<DateTime, String>,
-          List<Todo>>> getEverything() async {
+  Future<EverythingTuple> getEverything(
+      {void Function(EverythingTuple partial)? onProgress}) async {
     await Future.delayed(const Duration(seconds: 2));
     return Tuple7(
         [null, null],

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -31,7 +31,10 @@ class UgrsSpider implements Spider {
   bool _isPracticeScoresGet = false;
 
   Future<List<String?>>? _reloginFuture;
-  static const _retryableFetchErrors = <String>["无法解析", "iplanetdirectorypro无效"];
+  static const _retryableFetchErrors = <String>[
+    "无法解析",
+    "iplanetdirectorypro无效"
+  ];
 
   UgrsSpider(String username, String password) {
     _initHttpClient(); // 初始化客户端移到单独方法
@@ -224,22 +227,18 @@ class UgrsSpider implements Spider {
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-1').then((value) {
         if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-1']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          final config = jsonDecode(value.item2!);
+          outSemesters[semesterIndexMap['$yearStr-1']!].addZjuCalendar(config);
+          outSpecialDates.addAll((config['holiday'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(0, 8)),
+              '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(8, 16)),
+              '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+          outSpecialDates.addAll((config['dummy'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
         }
         return value.item1?.toString();
       }).catchError((e) => e.toString()));
@@ -247,22 +246,18 @@ class UgrsSpider implements Spider {
       semesterConfigFetches.add(
           _timeConfigService.getConfig(_httpClient, '$yearStr-2').then((value) {
         if (value.item2 != null) {
-          outSemesters[semesterIndexMap['$yearStr-2']!]
-              .addZjuCalendar(jsonDecode(value.item2!));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['holiday'] as Map)
-              .map((k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(0, 8)),
-                  '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['exchange'] as Map)
-              .map((k, v) => MapEntry(
-                  DateTime.parse((k as String).substring(8, 16)),
-                  '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
-          outSpecialDates.addAll((jsonDecode(value.item2!)['dummy'] as Map).map(
-              (k, v) =>
-                  MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          final config = jsonDecode(value.item2!);
+          outSemesters[semesterIndexMap['$yearStr-2']!].addZjuCalendar(config);
+          outSpecialDates.addAll((config['holiday'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(0, 8)),
+              '${v as String}放假·调 ${DateTime.parse(k.substring(8, 16)).month} 月 ${DateTime.parse(k.substring(8, 16)).day} 日')));
+          outSpecialDates.addAll((config['exchange'] as Map).map((k, v) => MapEntry(
+              DateTime.parse((k as String).substring(8, 16)),
+              '${v as String}调休·调 ${DateTime.parse(k.substring(0, 8)).month} 月 ${DateTime.parse(k.substring(0, 8)).day} 日')));
+          outSpecialDates.addAll((config['dummy'] as Map).map((k, v) =>
+              MapEntry(DateTime.parse(k as String), '${v as String}放假')));
         }
         return value.item1?.toString();
       }).catchError((e) => e.toString()));

--- a/lib/http/ugrs_spider.dart
+++ b/lib/http/ugrs_spider.dart
@@ -36,6 +36,20 @@ class UgrsSpider implements Spider {
     "iplanetdirectorypro无效"
   ];
 
+  /// getEverything 内各顶层抓取任务的标签，与抓取错误列表下标一一对应
+  static const List<String> fetchSequence = [
+    '校历',
+    '课表',
+    '考试',
+    '成绩',
+    '主修',
+    '作业',
+    '实践'
+  ];
+
+  @override
+  List<String> get fetchLabels => fetchSequence;
+
   UgrsSpider(String username, String password) {
     _initHttpClient(); // 初始化客户端移到单独方法
     _courses = Courses();
@@ -182,7 +196,6 @@ class UgrsSpider implements Spider {
   Future<EverythingTuple> getEverything(
       {void Function(EverythingTuple partial)? onProgress}) async {
     var fetches = <Future<String?>>[];
-    List<String> fetchSequence = ['校历', '课表', '考试', '成绩', '主修', '作业', '实践'];
 
     var outSemesters = <Semester>[];
     var outGrades = <Grade>[];

--- a/lib/http/zjuServices/courses.dart
+++ b/lib/http/zjuServices/courses.dart
@@ -10,66 +10,37 @@ import 'package:celechron/utils/tuple.dart';
 import 'package:celechron/model/todo.dart';
 
 class Courses {
+  static final Uri _todoUri = Uri.parse("https://courses.zju.edu.cn/api/todos");
+
   DatabaseHelper? _db;
   Cookie? _session;
-  Cookie? _iPlanetDirectoryPro; // ← 新增这一行，保存登录凭据
+  Cookie? _iPlanetDirectoryPro;
 
   set db(DatabaseHelper? db) {
     _db = db;
   }
 
   Future<Tuple<Exception?, List<Todo>>> getTodo(HttpClient httpClient) async {
-    late HttpClientRequest request;
-    late HttpClientResponse response;
-
     try {
-      if (_session == null) {
-        // ===== 改动：不再直接报错，而是尝试重新登录 =====
-        if (_iPlanetDirectoryPro != null) {
-          await login(httpClient, _iPlanetDirectoryPro);
-        } else {
-          throw ExceptionWithMessage("未登录");
-        }
-      }
-      request = await httpClient
-          .getUrl(Uri.parse("https://courses.zju.edu.cn/api/todos"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-      request.cookies.add(_session!);
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
+      await _ensureSession(httpClient);
+      var body = await _requestTodo(httpClient);
 
-      var body = await response.transform(utf8.decoder).join();
-
-      // 检查返回内容是否是登录页面（说明session过期了）
-      if (body.contains("cas/login") || body.contains("统一身份认证")) {
-        // session过期了，尝试重新登录
+      if (_isLoginPage(body)) {
         _session = null;
-        if (_iPlanetDirectoryPro != null) {
-          await login(httpClient, _iPlanetDirectoryPro);
-          // 重新请求
-          request = await httpClient
-              .getUrl(Uri.parse("https://courses.zju.edu.cn/api/todos"))
-              .timeout(const Duration(seconds: 8),
-                  onTimeout: () => throw ExceptionWithMessage("请求超时"));
-          request.cookies.add(_session!);
-          response = await request.close().timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("请求超时"));
-          body = await response.transform(utf8.decoder).join();
-        }
+        await _ensureSession(httpClient);
+        body = await _requestTodo(httpClient);
+      }
+      if (_isLoginPage(body)) {
+        throw ExceptionWithMessage("未登录");
       }
 
+      final todosJson = jsonDecode(body) as Map<String, dynamic>;
       _db?.setCachedWebPage("courses_todo", body);
 
-      return Tuple(null,
-          Todo.getAllFromCourses((jsonDecode(body) as Map<String, dynamic>)));
+      return Tuple(null, Todo.getAllFromCourses(todosJson));
     } catch (e) {
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
-      // 出错了也不怕，返回缓存数据，用户看不到报错
-      var todos = Todo.getAllFromCourses(
-          (jsonDecode(_db?.getCachedWebPage("courses_todo") ?? '{}')));
-      return Tuple(exception, todos);
+      var exception = _toException(e);
+      return Tuple(exception, _getCachedTodos());
     }
   }
 
@@ -81,29 +52,35 @@ class Courses {
       throw ExceptionWithMessage("iPlanetDirectoryPro无效");
     }
 
-    _iPlanetDirectoryPro = iPlanetDirectoryPro; // ← 新增：保存凭据以便自动重登
+    _session = null;
+    _iPlanetDirectoryPro = iPlanetDirectoryPro;
 
     var cookies = <Cookie>[iPlanetDirectoryPro];
 
     Future<void> getWithCookies(String url) async {
       request = await httpClient.getUrl(Uri.parse(url)).timeout(
-          const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
+            const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("请求超时"),
+          );
       request.followRedirects = false;
       request.cookies.addAll(cookies);
-      response = await request.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("请求超时"));
+      response = await request.close().timeout(
+            const Duration(seconds: 8),
+            onTimeout: () => throw ExceptionWithMessage("请求超时"),
+          );
       cookies.addAll(response.cookies);
       response.drain();
       if (response.isRedirect) {
         if (response.headers.value(HttpHeaders.locationHeader)! ==
             ("https://courses.zju.edu.cn/user/index")) {
-          _session =
-              response.cookies.firstWhere((cookie) => cookie.name == "session");
+          _session = response.cookies.firstWhere(
+            (cookie) => cookie.name == "session",
+          );
           return;
         }
         return await getWithCookies(
-            response.headers.value(HttpHeaders.locationHeader) as String);
+          response.headers.value(HttpHeaders.locationHeader) as String,
+        );
       }
     }
 
@@ -117,5 +94,50 @@ class Courses {
 
   void logout() {
     _session = null;
+    _iPlanetDirectoryPro = null;
+  }
+
+  Future<void> _ensureSession(HttpClient httpClient) async {
+    if (_session != null) return;
+
+    if (_iPlanetDirectoryPro == null) {
+      throw ExceptionWithMessage("未登录");
+    }
+    await login(httpClient, _iPlanetDirectoryPro);
+  }
+
+  Future<String> _requestTodo(HttpClient httpClient) async {
+    final request = await httpClient.getUrl(_todoUri).timeout(
+          const Duration(seconds: 8),
+          onTimeout: () => throw ExceptionWithMessage("请求超时"),
+        );
+    request.cookies.add(_session!);
+    final response = await request.close().timeout(
+          const Duration(seconds: 8),
+          onTimeout: () => throw ExceptionWithMessage("请求超时"),
+        );
+
+    return await response.transform(utf8.decoder).join();
+  }
+
+  bool _isLoginPage(String body) {
+    return body.contains("cas/login") || body.contains("统一身份认证");
+  }
+
+  List<Todo> _getCachedTodos() {
+    try {
+      final cached = _db?.getCachedWebPage("courses_todo");
+      if (cached == null) return [];
+
+      return Todo.getAllFromCourses(jsonDecode(cached) as Map<String, dynamic>);
+    } catch (_) {
+      return [];
+    }
+  }
+
+  Exception _toException(Object error) {
+    if (error is SocketException) return ExceptionWithMessage("网络错误");
+    if (error is Exception) return error;
+    return ExceptionWithMessage(error.toString());
   }
 }

--- a/lib/http/zjuServices/exceptions.dart
+++ b/lib/http/zjuServices/exceptions.dart
@@ -22,3 +22,7 @@ class ExceptionWithMessage implements Exception {
     return "$message";
   }
 }
+
+class SessionExpiredException extends ExceptionWithMessage {
+  SessionExpiredException() : super("会话已过期");
+}

--- a/lib/http/zjuServices/grs_new.dart
+++ b/lib/http/zjuServices/grs_new.dart
@@ -13,7 +13,8 @@ import 'package:quiver/time.dart';
 
 class GrsNew {
   String? _token;
-  Cookie? _ssoCookie; // ← 【新增】保存登录凭据，以便自动重登
+  Cookie? _ssoCookie;
+  Future<void>? _reloginFuture;
   // ignore: unused_field
   DatabaseHelper? _db;
 
@@ -29,7 +30,8 @@ class GrsNew {
       throw ExceptionWithMessage("Invalid ssoCookie");
     }
 
-    _ssoCookie = ssoCookie; // ← 【新增】保存凭据
+    _token = null;
+    _ssoCookie = ssoCookie;
 
     req = await httpClient
         .getUrl(Uri.parse(
@@ -75,20 +77,34 @@ class GrsNew {
 
   void logout() {
     _token = null;
-    _ssoCookie = null; // ← 【新增】退出时也清除
+    _ssoCookie = null;
+    _reloginFuture = null;
   }
 
-  // ===== 【新增】自动重登辅助方法 =====
-  // 当 _token 失效时，用保存的 _ssoCookie 自动重新登录
   Future<void> _relogin(HttpClient httpClient) async {
-    if (_ssoCookie == null) {
+    final ssoCookie = _ssoCookie;
+    if (ssoCookie == null) {
       throw ExceptionWithMessage("会话已过期，请重新登录");
     }
-    _token = null; // 清掉旧的失效token
-    await login(httpClient, _ssoCookie);
+
+    final future = _reloginFuture ??= _doRelogin(
+      httpClient,
+      ssoCookie,
+    );
+    try {
+      await future;
+    } finally {
+      if (identical(_reloginFuture, future)) {
+        _reloginFuture = null;
+      }
+    }
   }
 
-  // 检查API返回结果是否表示token已失效
+  Future<void> _doRelogin(HttpClient httpClient, Cookie ssoCookie) async {
+    _token = null;
+    await login(httpClient, ssoCookie);
+  }
+
   bool _isTokenExpired(Map<String, dynamic> result) {
     if (result["success"] == false) {
       String msg = (result["message"] ?? "").toString().toLowerCase();
@@ -107,51 +123,62 @@ class GrsNew {
     }
     return false;
   }
-  // ===== 【新增结束】 =====
+
+  Future<void> _ensureToken(HttpClient httpClient) async {
+    if (_token != null) return;
+
+    if (_ssoCookie != null) {
+      await _relogin(httpClient);
+      return;
+    }
+
+    throw ExceptionWithMessage("not logged in");
+  }
+
+  Future<Map<String, dynamic>> _requestJsonWithToken(
+    HttpClient httpClient,
+    Uri uri, {
+    String method = 'GET',
+  }) async {
+    await _ensureToken(httpClient);
+    var result = await _requestJson(httpClient, uri, method: method);
+    if (!_isTokenExpired(result)) return result;
+
+    await _relogin(httpClient);
+    return await _requestJson(httpClient, uri, method: method);
+  }
+
+  Future<Map<String, dynamic>> _requestJson(
+    HttpClient httpClient,
+    Uri uri, {
+    String method = 'GET',
+  }) async {
+    final request = await (method.toUpperCase() == 'POST'
+            ? httpClient.postUrl(uri)
+            : httpClient.getUrl(uri))
+        .timeout(
+      const Duration(seconds: 8),
+      onTimeout: () => throw ExceptionWithMessage("request timeout"),
+    );
+    request.headers.add("X-Access-Token", _token!);
+    final response = await request.close().timeout(
+          const Duration(seconds: 8),
+          onTimeout: () => throw ExceptionWithMessage("request timeout"),
+        );
+    final resultJson = await response.transform(utf8.decoder).join();
+
+    return jsonDecode(resultJson) as Map<String, dynamic>;
+  }
 
   Future<Tuple<Exception?, Iterable<Grade>>> getGrade(
       HttpClient httpClient) async {
-    late HttpClientRequest req;
-    late HttpClientResponse res;
     try {
-      if (_token == null) {
-        // 【改动】不再直接报错，而是尝试自动重登
-        if (_ssoCookie != null) {
-          await _relogin(httpClient);
-        } else {
-          throw ExceptionWithMessage("not logged in");
-        }
-      }
-      req = await httpClient
-          .postUrl(Uri.parse(
-              "https://yjsy.zju.edu.cn/dataapi/py/pyXsxk/queryXsxkByXnxqXs"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      req.headers.add("X-Access-Token", _token!);
-      res = await req.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      final resultJson = await res.transform(utf8.decoder).join();
-      final result = jsonDecode(resultJson) as Map<String, dynamic>;
-
-      // 【新增】检查token是否过期，过期则自动重登再重试一次
-      if (_isTokenExpired(result)) {
-        await _relogin(httpClient);
-        req = await httpClient
-            .postUrl(Uri.parse(
-                "https://yjsy.zju.edu.cn/dataapi/py/pyXsxk/queryXsxkByXnxqXs"))
-            .timeout(const Duration(seconds: 8),
-                onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        req.headers.add("X-Access-Token", _token!);
-        res = await req.close().timeout(const Duration(seconds: 8),
-            onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        final retryJson = await res.transform(utf8.decoder).join();
-        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
-        if (retryResult["success"] != true) {
-          throw ExceptionWithMessage(
-              '获取成绩api错误，错误信息为 ${retryResult["message"]}');
-        }
-        return _parseGrades(retryResult);
-      }
+      final result = await _requestJsonWithToken(
+        httpClient,
+        Uri.parse(
+            "https://yjsy.zju.edu.cn/dataapi/py/pyXsxk/queryXsxkByXnxqXs"),
+        method: 'POST',
+      );
 
       if (result["success"] != true) {
         throw ExceptionWithMessage('获取成绩api错误，错误信息为 ${result["message"]}');
@@ -159,13 +186,11 @@ class GrsNew {
 
       return _parseGrades(result);
     } catch (e) {
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+      var exception = _toException(e);
       return Tuple(exception, []);
     }
   }
 
-  // 【新增】把成绩解析提取成单独方法，避免重复代码
   Tuple<Exception?, Iterable<Grade>> _parseGrades(Map<String, dynamic> result) {
     final rawGrades = (result["result"]?["xxjhnList"] as List?) ?? [];
     if (rawGrades.isEmpty) {
@@ -211,48 +236,12 @@ class GrsNew {
 
   Future<Tuple<Exception?, Iterable<ExamDto>>> getExamsDto(
       HttpClient httpClient, int year, int semester) async {
-    late HttpClientRequest req;
-    late HttpClientResponse res;
     try {
-      if (_token == null) {
-        // 【改动】不再直接报错，而是尝试自动重登
-        if (_ssoCookie != null) {
-          await _relogin(httpClient);
-        } else {
-          throw ExceptionWithMessage("not logged in");
-        }
-      }
-
-      req = await httpClient
-          .getUrl(Uri.parse(
-              "https://yjsy.zju.edu.cn/dataapi/py/pyKsxsxx/queryPageByXs?dm=py_grks&mode=2&role=1&column=createTime&order=desc&queryMode=1&field=id,,kcbh,kcmc,rq,ksTime,xn,xq_dictText,ksdd,zwh&pageNo=1&pageSize=100&xn=$year&xq=$semester"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      req.headers.add("X-Access-Token", _token!);
-      res = await req.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      final resultJson = await res.transform(utf8.decoder).join();
-      final result = jsonDecode(resultJson) as Map<String, dynamic>;
-
-      // 【新增】检查token是否过期
-      if (_isTokenExpired(result)) {
-        await _relogin(httpClient);
-        req = await httpClient
-            .getUrl(Uri.parse(
-                "https://yjsy.zju.edu.cn/dataapi/py/pyKsxsxx/queryPageByXs?dm=py_grks&mode=2&role=1&column=createTime&order=desc&queryMode=1&field=id,,kcbh,kcmc,rq,ksTime,xn,xq_dictText,ksdd,zwh&pageNo=1&pageSize=100&xn=$year&xq=$semester"))
-            .timeout(const Duration(seconds: 8),
-                onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        req.headers.add("X-Access-Token", _token!);
-        res = await req.close().timeout(const Duration(seconds: 8),
-            onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        final retryJson = await res.transform(utf8.decoder).join();
-        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
-        if (retryResult["success"] != true) {
-          throw ExceptionWithMessage(
-              "获取考试api错误，错误信息为 ${retryResult["message"]}");
-        }
-        return _parseExams(retryResult, year);
-      }
+      final result = await _requestJsonWithToken(
+        httpClient,
+        Uri.parse(
+            "https://yjsy.zju.edu.cn/dataapi/py/pyKsxsxx/queryPageByXs?dm=py_grks&mode=2&role=1&column=createTime&order=desc&queryMode=1&field=id,,kcbh,kcmc,rq,ksTime,xn,xq_dictText,ksdd,zwh&pageNo=1&pageSize=100&xn=$year&xq=$semester"),
+      );
 
       if (result["success"] != true) {
         throw ExceptionWithMessage("获取考试api错误，错误信息为 ${result["message"]}");
@@ -260,13 +249,11 @@ class GrsNew {
 
       return _parseExams(result, year);
     } catch (e) {
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+      var exception = _toException(e);
       return Tuple(exception, []);
     }
   }
 
-  // 【新增】把考试解析提取成单独方法
   Tuple<Exception?, Iterable<ExamDto>> _parseExams(
       Map<String, dynamic> result, int year) {
     final rawExams = result["result"] as List<dynamic>;
@@ -342,32 +329,7 @@ class GrsNew {
         url += "&kcbh=${Uri.encodeComponent(sessionId)}";
         url += "&kcmc=${Uri.encodeComponent(courseSessions.first.name)}";
         url += "&zjjsJzgId=${Uri.encodeComponent(teacherId)}";
-        var req = await httpClient.getUrl(Uri.parse(url)).timeout(
-            const Duration(seconds: 8),
-            onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        req.headers.add("X-Access-Token", _token!);
-        var res = await req.close().timeout(const Duration(seconds: 8),
-            onTimeout: () => throw ExceptionWithMessage("request timeout"));
-
-        final resultJson = await res.transform(utf8.decoder).join();
-        final result = jsonDecode(resultJson) as Map<String, dynamic>;
-
-        // 【新增】如果token过期，尝试重登再重试
-        if (_isTokenExpired(result) && _ssoCookie != null) {
-          await _relogin(httpClient);
-          req = await httpClient.getUrl(Uri.parse(url)).timeout(
-              const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("request timeout"));
-          req.headers.add("X-Access-Token", _token!);
-          res = await req.close().timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("request timeout"));
-          final retryJson = await res.transform(utf8.decoder).join();
-          final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
-          if (retryResult["success"] == true) {
-            _applyCourseDetails(retryResult, courseSessions);
-          }
-          return;
-        }
+        final result = await _requestJsonWithToken(httpClient, Uri.parse(url));
 
         if (result["success"] == true) {
           _applyCourseDetails(result, courseSessions);
@@ -378,7 +340,6 @@ class GrsNew {
     }));
   }
 
-  // 【新增】把课程详情解析提取成独立方法
   void _applyCourseDetails(
       Map<String, dynamic> result, List<Session> courseSessions) {
     final records = result["result"]?["records"] as List?;
@@ -413,49 +374,12 @@ class GrsNew {
 
   Future<Tuple<Exception?, Iterable<Session>>> getTimetable(
       HttpClient httpClient, int year, int semester) async {
-    late HttpClientRequest req;
-    late HttpClientResponse res;
     try {
-      if (_token == null) {
-        // 【改动】不再直接报错，而是尝试自动重登
-        if (_ssoCookie != null) {
-          await _relogin(httpClient);
-        } else {
-          throw ExceptionWithMessage("not logged in");
-        }
-      }
-
-      req = await httpClient
-          .getUrl(Uri.parse(
-              "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryXskbByLoginUser?xn=$year&pkxq=$semester"))
-          .timeout(const Duration(seconds: 8),
-              onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      req.headers.add("X-Access-Token", _token!);
-      res = await req.close().timeout(const Duration(seconds: 8),
-          onTimeout: () => throw ExceptionWithMessage("request timeout"));
-      final resultJson = await res.transform(utf8.decoder).join();
-
-      final result = jsonDecode(resultJson) as Map<String, dynamic>;
-
-      // 【新增】检查token是否过期
-      if (_isTokenExpired(result)) {
-        await _relogin(httpClient);
-        req = await httpClient
-            .getUrl(Uri.parse(
-                "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryXskbByLoginUser?xn=$year&pkxq=$semester"))
-            .timeout(const Duration(seconds: 8),
-                onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        req.headers.add("X-Access-Token", _token!);
-        res = await req.close().timeout(const Duration(seconds: 8),
-            onTimeout: () => throw ExceptionWithMessage("request timeout"));
-        final retryJson = await res.transform(utf8.decoder).join();
-        final retryResult = jsonDecode(retryJson) as Map<String, dynamic>;
-        if (retryResult["success"] != true) {
-          throw ExceptionWithMessage(
-              "获取课程api错误，错误信息为 ${retryResult["message"]}");
-        }
-        return _parseTimetable(httpClient, retryResult, year, semester);
-      }
+      final result = await _requestJsonWithToken(
+        httpClient,
+        Uri.parse(
+            "https://yjsy.zju.edu.cn/dataapi/py/pyKcbj/queryXskbByLoginUser?xn=$year&pkxq=$semester"),
+      );
 
       if (result["success"] != true) {
         throw ExceptionWithMessage("获取课程api错误，错误信息为 ${result["message"]}");
@@ -463,13 +387,11 @@ class GrsNew {
 
       return _parseTimetable(httpClient, result, year, semester);
     } catch (e) {
-      var exception =
-          e is SocketException ? ExceptionWithMessage("网络错误") : e as Exception;
+      var exception = _toException(e);
       return Tuple(exception, []);
     }
   }
 
-  // 【新增】把课表解析提取成独立方法
   Future<Tuple<Exception?, Iterable<Session>>> _parseTimetable(
       HttpClient httpClient,
       Map<String, dynamic> result,
@@ -559,6 +481,10 @@ class GrsNew {
 
     return Tuple(null, sessions);
   }
-}
 
-void main() async {}
+  Exception _toException(Object error) {
+    if (error is SocketException) return ExceptionWithMessage("网络错误");
+    if (error is Exception) return error;
+    return ExceptionWithMessage(error.toString());
+  }
+}

--- a/lib/http/zjuServices/zdbk.dart
+++ b/lib/http/zjuServices/zdbk.dart
@@ -12,17 +12,13 @@ import 'package:celechron/design/captcha_input.dart';
 import 'package:celechron/utils/global.dart';
 import 'exceptions.dart';
 
-// 定义一个特定的会话过期异常，方便上层捕获重试
-class SessionExpiredException extends ExceptionWithMessage {
-  SessionExpiredException() : super("会话已过期");
-}
-
 class Zdbk {
   Cookie? _jSessionId;
   Cookie? _route;
-  Cookie? _iPlanetDirectoryPro; // 新增：保存登录凭据
+  Cookie? _iPlanetDirectoryPro;
   String? _captcha;
   DatabaseHelper? _db;
+  Future<void>? _reloginFuture;
 
   set db(DatabaseHelper? db) {
     _db = db;
@@ -32,12 +28,14 @@ class Zdbk {
     late HttpClientRequest request;
     late HttpClientResponse response;
 
-    _captcha = null;
-    _iPlanetDirectoryPro = iPlanetDirectoryPro; // 保存以便自动重登
-
     if (iPlanetDirectoryPro == null) {
       throw ExceptionWithMessage("iPlanetDirectoryPro无效");
     }
+    _jSessionId = null;
+    _route = null;
+    _captcha = null;
+    _iPlanetDirectoryPro = iPlanetDirectoryPro;
+
     request = await httpClient
         .getUrl(Uri.parse(
             "https://zjuam.zju.edu.cn/cas/login?service=https%3A%2F%2Fzdbk.zju.edu.cn%2Fjwglxt%2Fxtgl%2Flogin_ssologin.html"))
@@ -84,7 +82,9 @@ class Zdbk {
   void logout() {
     _jSessionId = null;
     _route = null;
+    _iPlanetDirectoryPro = null;
     _captcha = null;
+    _reloginFuture = null;
   }
 
   void _checkSessionExpired(HttpClientResponse response, String responseText) {
@@ -100,11 +100,49 @@ class Zdbk {
     }
   }
 
+  Exception _toException(Object error) {
+    if (error is SocketException) return ExceptionWithMessage("网络错误");
+    if (error is Exception) return error;
+    return ExceptionWithMessage(error.toString());
+  }
+
+  List<Map<String, dynamic>> _getCachedJsonMaps(String key) {
+    try {
+      final cached = _db?.getCachedWebPage(key);
+      if (cached == null) return [];
+
+      final decoded = jsonDecode(cached);
+      if (decoded is! List) return [];
+      return decoded.whereType<Map<String, dynamic>>().toList();
+    } catch (_) {
+      return [];
+    }
+  }
+
   Future<void> _relogin(HttpClient httpClient) async {
-    if (_iPlanetDirectoryPro == null) {
+    final iPlanetDirectoryPro = _iPlanetDirectoryPro;
+    if (iPlanetDirectoryPro == null) {
       throw ExceptionWithMessage("会话已过期，请重新登录");
     }
-    await login(httpClient, _iPlanetDirectoryPro);
+
+    final future = _reloginFuture ??= _doRelogin(
+      httpClient,
+      iPlanetDirectoryPro,
+    );
+    try {
+      await future;
+    } finally {
+      if (identical(_reloginFuture, future)) {
+        _reloginFuture = null;
+      }
+    }
+  }
+
+  Future<void> _doRelogin(
+    HttpClient httpClient,
+    Cookie iPlanetDirectoryPro,
+  ) async {
+    await login(httpClient, iPlanetDirectoryPro);
   }
 
   Future<T> _withAutoRelogin<T>(
@@ -169,18 +207,15 @@ class Zdbk {
             null, Tuple([majorGpa.item1[0], majorGpa.item2], responseText));
       } catch (e) {
         if (e is SessionExpiredException) rethrow;
-        var exception = e is SocketException
-            ? ExceptionWithMessage("网络错误")
-            : e as Exception;
-        var cachedJson = _db?.getCachedWebPage('zdbk_MajorGrade') ?? '[]';
-        var grades = (jsonDecode(cachedJson) as List<dynamic>)
-            .where((e) => e['xkkh'] != null)
-            .map((e) {
+        var exception = _toException(e);
+        var cachedItems = _getCachedJsonMaps('zdbk_MajorGrade');
+        var grades = cachedItems.where((e) => e['xkkh'] != null).map((e) {
           var grade = Grade(e);
           grade.major = true;
           return grade;
         });
         var majorGpa = GpaHelper.calculateGpa(grades);
+        var cachedJson = jsonEncode(cachedItems);
         return Tuple(
             exception,
             Tuple([majorGpa.item1[0], majorGpa.item2],
@@ -230,13 +265,10 @@ class Zdbk {
         return Tuple(null, grades);
       } catch (e) {
         if (e is SessionExpiredException) rethrow;
-        var exception = e is SocketException
-            ? ExceptionWithMessage("网络错误")
-            : e as Exception;
+        var exception = _toException(e);
         return Tuple(
             exception,
-            (jsonDecode((_db?.getCachedWebPage('zdbk_Transcript') ?? '[]'))
-                    as List<dynamic>)
+            _getCachedJsonMaps('zdbk_Transcript')
                 .where((e) => e['xkkh'] != null)
                 .map((e) => Grade(e)));
       }
@@ -309,15 +341,11 @@ class Zdbk {
         throw ExceptionWithMessage("验证码识别失败");
       } catch (e) {
         if (e is SessionExpiredException) rethrow;
-        var exception = e is SocketException
-            ? ExceptionWithMessage("网络错误")
-            : e as Exception;
+        var exception = _toException(e);
         return Tuple(
             exception,
-            (jsonDecode(
-                    (_db?.getCachedWebPage('zdbk_Timetable$year$semester') ??
-                        '[]')) as List<dynamic>)
-                .where((e) => e['kcb'] != null && (e['sfyjskc'] != "1"))
+            _getCachedJsonMaps('zdbk_Timetable$year$semester')
+                .where((e) => e['kcb'] != null && e['sfyjskc'] != "1")
                 .map((e) => Session.fromZdbk(e)));
       }
     });
@@ -364,13 +392,10 @@ class Zdbk {
         return Tuple(null, exams);
       } catch (e) {
         if (e is SessionExpiredException) rethrow;
-        var exception = e is SocketException
-            ? ExceptionWithMessage("网络错误")
-            : e as Exception;
+        var exception = _toException(e);
         return Tuple(
             exception,
-            (jsonDecode((_db?.getCachedWebPage('zdbk_exams') ?? '[]'))
-                    as List<dynamic>)
+            _getCachedJsonMaps('zdbk_exams')
                 .where((e) => e['xkkh'] != null)
                 .map((e) => ExamDto.fromZdbk(e)));
       }
@@ -471,9 +496,7 @@ class Zdbk {
       } catch (e) {
         if (e is SessionExpiredException) rethrow;
 
-        var exception = e is SocketException
-            ? ExceptionWithMessage("网络错误")
-            : e as Exception;
+        var exception = _toException(e);
 
         var cachedHtml = _db?.getCachedWebPage("zdbk_practiceScores");
         if (cachedHtml != null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,7 @@ void main() async {
         .login()
         .then((value) async {
           GlobalStatus.isFirstScreenReq = true;
-          await scholar.value.refresh();
+          await scholar.value.refresh(onPartialUpdate: scholar.refresh);
           GlobalStatus.isFirstScreenReq = false;
         })
         .then((value) => scholar.refresh())

--- a/lib/model/option.dart
+++ b/lib/model/option.dart
@@ -32,6 +32,7 @@ class Option {
   Rx<BrightnessMode> brightnessMode;
   RxList<CourseIdMap> courseIdMappingList;
   RxBool hideHomeGpa;
+  RxBool asyncRefresh;
 
   Option({
     required this.workTime,
@@ -43,5 +44,6 @@ class Option {
     required this.brightnessMode,
     required this.courseIdMappingList,
     required this.hideHomeGpa,
+    required this.asyncRefresh,
   });
 }

--- a/lib/model/scholar.dart
+++ b/lib/model/scholar.dart
@@ -147,7 +147,9 @@ class Scholar {
   // 刷新数据
   var _mutex = 0;
 
-  Future<List<String?>> refresh({void Function()? onPartialUpdate}) async {
+  Future<List<String?>> refresh(
+      {void Function()? onPartialUpdate,
+      void Function(List<ModuleFetchStatus> statuses)? onFetchStatus}) async {
     if (!isLogan) {
       return ["未登录"];
     }
@@ -164,24 +166,50 @@ class Scholar {
       // 全部完成后仍会走下面的完整合并（含实践学分、时间戳、持久化与报错）
       var useAsyncRefresh =
           onPartialUpdate != null && (_db?.getAsyncRefresh() ?? false);
+      // 刷新状态文案：与数据合并解耦，只要有人监听就照常上报各模块进度，
+      // 不受异步刷新开关影响；后台刷新两个回调都不传，行为与原来完全一致
+      var fetchLabels = _spider?.fetchLabels ?? const <String>[];
+      void emitStatuses(List<String?> fetchErrors) {
+        if (onFetchStatus == null || fetchLabels.isEmpty) return;
+        try {
+          var statuses = moduleStatusesFromErrors(fetchErrors, fetchLabels);
+          if (statuses.isNotEmpty) onFetchStatus(statuses);
+        } catch (e) {
+          // 状态上报失败不影响刷新本身
+          // ignore: avoid_print
+          print('fetch status error: $e');
+        }
+      }
+
+      // 起始状态：全部「进行中」（覆盖登录阶段，此时尚无任何任务完成回调）
+      if (onFetchStatus != null && fetchLabels.isNotEmpty) {
+        onFetchStatus([
+          for (var label in fetchLabels)
+            ModuleFetchStatus(label, FetchModuleState.pending)
+        ]);
+      }
+      var wantProgress = useAsyncRefresh || onFetchStatus != null;
       return await _spider
               ?.getEverything(
-                  onProgress: useAsyncRefresh
+                  onProgress: wantProgress
                       ? (partial) {
-                          try {
-                            _applyFetchResult(partial, partial: true);
-                            // 已成功板块立即打上“更新于”时间戳；
-                            // 未完成/失败的板块被 updateLastUpdateTime 的
-                            // 关键字守卫（“查询进行中”/“查询出错”）拦下
-                            if (partial.item1.every((e) => e == null)) {
-                              updateLastUpdateTime(partial.item2);
+                          if (useAsyncRefresh) {
+                            try {
+                              _applyFetchResult(partial, partial: true);
+                              // 已成功板块立即打上“更新于”时间戳；
+                              // 未完成/失败的板块被 updateLastUpdateTime 的
+                              // 关键字守卫（“查询进行中”/“查询出错”）拦下
+                              if (partial.item1.every((e) => e == null)) {
+                                updateLastUpdateTime(partial.item2);
+                              }
+                              onPartialUpdate();
+                            } catch (e) {
+                              // 中间态合并失败不影响整体刷新，最终合并会兜底
+                              // ignore: avoid_print
+                              print('partial refresh error: $e');
                             }
-                            onPartialUpdate();
-                          } catch (e) {
-                            // 中间态合并失败不影响整体刷新，最终合并会兜底
-                            // ignore: avoid_print
-                            print('partial refresh error: $e');
                           }
+                          emitStatuses(partial.item2);
                         }
                       : null)
               .then((value) async {
@@ -197,6 +225,9 @@ class Scholar {
               updateLastUpdateTime(value.item2);
             }
             _applyFetchResult(value);
+
+            // 终态补发：最后完成的模块不会触发 onProgress，只能在这里定论
+            emitStatuses(value.item2);
 
             await _db?.setScholar(this);
             return value.item1.every((e) => e == null)

--- a/lib/model/scholar.dart
+++ b/lib/model/scholar.dart
@@ -147,7 +147,7 @@ class Scholar {
   // 刷新数据
   var _mutex = 0;
 
-  Future<List<String?>> refresh() async {
+  Future<List<String?>> refresh({void Function()? onPartialUpdate}) async {
     if (!isLogan) {
       return ["未登录"];
     }
@@ -160,7 +160,31 @@ class Scholar {
     }
     _mutex++;
     try {
-      return await _spider?.getEverything().then((value) async {
+      // 异步刷新：每完成一部分抓取就先合并进内存并通知界面，
+      // 全部完成后仍会走下面的完整合并（含实践学分、时间戳、持久化与报错）
+      var useAsyncRefresh =
+          onPartialUpdate != null && (_db?.getAsyncRefresh() ?? false);
+      return await _spider
+              ?.getEverything(
+                  onProgress: useAsyncRefresh
+                      ? (partial) {
+                          try {
+                            _applyFetchResult(partial, partial: true);
+                            // 已成功板块立即打上“更新于”时间戳；
+                            // 未完成/失败的板块被 updateLastUpdateTime 的
+                            // 关键字守卫（“查询进行中”/“查询出错”）拦下
+                            if (partial.item1.every((e) => e == null)) {
+                              updateLastUpdateTime(partial.item2);
+                            }
+                            onPartialUpdate();
+                          } catch (e) {
+                            // 中间态合并失败不影响整体刷新，最终合并会兜底
+                            // ignore: avoid_print
+                            print('partial refresh error: $e');
+                          }
+                        }
+                      : null)
+              .then((value) async {
             for (var e in value.item1) {
               // ignore: avoid_print
               if (e != null) print(e);
@@ -172,78 +196,7 @@ class Scholar {
             if (value.item1.every((e) => e == null)) {
               updateLastUpdateTime(value.item2);
             }
-            var tempSemester = value.item3;
-            var tempGrades = value.item4.fold(<String, List<Grade>>{}, (p, e) {
-              // 体育课
-              var matchClass = RegExp(r'(\(.*\)-(.*?))-.*').firstMatch(e.id);
-              var key = matchClass?.group(2) ?? e.id.substring(14, 22);
-              if (key.startsWith('PPAE') || key.startsWith('401')) {
-                key = matchClass?.group(1) ?? e.id.substring(0, 22);
-              }
-              var courseIdMappingList =
-                  Get.find<OptionController>(tag: 'optionController')
-                      .courseIdMappingList;
-              var courseIdMappingMap = {
-                for (var e in courseIdMappingList) e.id1: e.id2
-              };
-              if (courseIdMappingMap.containsKey(key)) {
-                key = courseIdMappingMap[key]!;
-              }
-              p.putIfAbsent(key, () => <Grade>[]).add(e);
-              return p;
-            });
-            var tempMajorGpaAndCredit = value.item5;
-            var tempSpecialDates = value.item6;
-            var tempTodos = value.item7;
-
-            var tempIsPracticeScoresGet = false;
-            var tempPt2 = 0.0, tempPt3 = 0.0, tempPt4 = 0.0;
-            // 获取实践学分数据（仅本科生）
-            if (_spider is UgrsSpider && !isGrs) {
-              var ugrsSpider = _spider as UgrsSpider;
-              tempIsPracticeScoresGet = ugrsSpider.isPracticeScoresGet;
-              if (tempIsPracticeScoresGet) {
-                var practiceScores = ugrsSpider.practiceScores;
-                if (practiceScores != null) {
-                  tempPt2 = practiceScores['pt2'] ?? 0.0;
-                  tempPt3 = practiceScores['pt3'] ?? 0.0;
-                  tempPt4 = practiceScores['pt4'] ?? 0.0;
-                }
-              }
-            } else {
-              tempIsPracticeScoresGet = false;
-            }
-
-            setScholar(
-                value.item2,
-                tempSemester,
-                tempGrades,
-                tempMajorGpaAndCredit,
-                tempSpecialDates,
-                tempTodos,
-                tempIsPracticeScoresGet,
-                tempPt2,
-                tempPt3,
-                tempPt4);
-
-            // 保研成绩，只取第一次
-            var netGrades = grades.values.map((e) => e.first);
-            if (netGrades.isNotEmpty) {
-              gpa = GpaHelper.calculateGpa(netGrades).item1;
-            }
-            // 出国成绩，取最高的一次
-            var aboardNetGrades = grades.values.map((e) {
-              e.sort((a, b) => a.hundredPoint.compareTo(b.hundredPoint));
-              return e.last;
-            });
-            if (aboardNetGrades.isNotEmpty) {
-              var result = GpaHelper.calculateGpa(aboardNetGrades);
-              aboardGpa = result.item1;
-              // 所获学分，不包括挂科的。
-              credit = result.item2;
-            } else {
-              credit = 0.0;
-            }
+            _applyFetchResult(value);
 
             await _db?.setScholar(this);
             return value.item1.every((e) => e == null)
@@ -258,6 +211,88 @@ class Scholar {
       return ['网络连接失败，请检查网络后重试'];
     } finally {
       _mutex--;
+    }
+  }
+
+  // 把一次抓取结果合并进当前对象。partial 为 true 表示异步刷新的中间态：
+  // 空数据、有报错或尚未抓完的部分会被 setScholar 的守卫拦下，保留原值；
+  // 实践学分成功与否要等全部抓完才能判定，中间态一律保持不变。
+  void _applyFetchResult(EverythingTuple value, {bool partial = false}) {
+    var tempSemester = value.item3;
+    var tempGrades = value.item4.fold(<String, List<Grade>>{}, (p, e) {
+      // 体育课
+      var matchClass = RegExp(r'(\(.*\)-(.*?))-.*').firstMatch(e.id);
+      var key = matchClass?.group(2) ?? e.id.substring(14, 22);
+      if (key.startsWith('PPAE') || key.startsWith('401')) {
+        key = matchClass?.group(1) ?? e.id.substring(0, 22);
+      }
+      var courseIdMappingList =
+          Get.find<OptionController>(tag: 'optionController')
+              .courseIdMappingList;
+      var courseIdMappingMap = {
+        for (var e in courseIdMappingList) e.id1: e.id2
+      };
+      if (courseIdMappingMap.containsKey(key)) {
+        key = courseIdMappingMap[key]!;
+      }
+      p.putIfAbsent(key, () => <Grade>[]).add(e);
+      return p;
+    });
+    var tempMajorGpaAndCredit = value.item5;
+    var tempSpecialDates = value.item6;
+    var tempTodos = value.item7;
+
+    var tempIsPracticeScoresGet = partial ? isPracticeScoresGet : false;
+    var tempPt2 = partial ? pt2 : 0.0;
+    var tempPt3 = partial ? pt3 : 0.0;
+    var tempPt4 = partial ? pt4 : 0.0;
+    if (!partial) {
+      // 获取实践学分数据（仅本科生）
+      if (_spider is UgrsSpider && !isGrs) {
+        var ugrsSpider = _spider as UgrsSpider;
+        tempIsPracticeScoresGet = ugrsSpider.isPracticeScoresGet;
+        if (tempIsPracticeScoresGet) {
+          var practiceScores = ugrsSpider.practiceScores;
+          if (practiceScores != null) {
+            tempPt2 = practiceScores['pt2'] ?? 0.0;
+            tempPt3 = practiceScores['pt3'] ?? 0.0;
+            tempPt4 = practiceScores['pt4'] ?? 0.0;
+          }
+        }
+      } else {
+        tempIsPracticeScoresGet = false;
+      }
+    }
+
+    setScholar(
+        value.item2,
+        tempSemester,
+        tempGrades,
+        tempMajorGpaAndCredit,
+        tempSpecialDates,
+        tempTodos,
+        tempIsPracticeScoresGet,
+        tempPt2,
+        tempPt3,
+        tempPt4);
+
+    // 保研成绩，只取第一次
+    var netGrades = grades.values.map((e) => e.first);
+    if (netGrades.isNotEmpty) {
+      gpa = GpaHelper.calculateGpa(netGrades).item1;
+    }
+    // 出国成绩，取最高的一次
+    var aboardNetGrades = grades.values.map((e) {
+      e.sort((a, b) => a.hundredPoint.compareTo(b.hundredPoint));
+      return e.last;
+    });
+    if (aboardNetGrades.isNotEmpty) {
+      var result = GpaHelper.calculateGpa(aboardNetGrades);
+      aboardGpa = result.item1;
+      // 所获学分，不包括挂科的。
+      credit = result.item2;
+    } else {
+      credit = 0.0;
     }
   }
 

--- a/lib/model/semester.dart
+++ b/lib/model/semester.dart
@@ -144,7 +144,15 @@ class Semester {
                 (e.time.length) * ((e.oddWeek ? 1 : 0) + (e.evenWeek ? 1 : 0)));
   }
 
-  List<Period> get periods {
+  List<Period>? _periodsCache;
+
+  void _invalidatePeriodsCache() => _periodsCache = null;
+
+  // 构建代价高，缓存结果；任何影响构建输入的 mutator 都必须调用 _invalidatePeriodsCache。
+  // 调用方不得原地修改返回的列表（需要排序等操作时先拷贝）。
+  List<Period> get periods => _periodsCache ??= _buildPeriods();
+
+  List<Period> _buildPeriods() {
     List<Period> periods = [];
     for (var session in _sessions) {
       // 自定义单双周的课程在后面处理（目前均为研究生课）
@@ -313,6 +321,8 @@ class Semester {
   }
 
   void addSession(Session session, String semesterId, [bool isGrs = false]) {
+    // completeSession 即使判定重复也会改写已存 Session 的 firstHalf/secondHalf/id，必须失效缓存
+    _invalidatePeriodsCache();
     // 由于ZDBK不给课号，Session的id初始值为null，不能直接拿来用！
     var key = '$semesterId${session.name}';
     if (_courses.containsKey(key)) {
@@ -336,6 +346,7 @@ class Semester {
   }
 
   void addExamWithSemester(ExamDto examDto, String semesterId) {
+    _invalidatePeriodsCache();
     // 有的课没有考试，但是能查到考试信息，其考试时间为null。
     _exams.addAll(examDto.exams);
     var key = '$semesterId${examDto.name}';
@@ -352,6 +363,8 @@ class Semester {
 
   void addGradeWithSemester(Grade grade, String semesterId,
       [bool isGrs = false]) {
+    // completeGrade 可能把已存 Session 的 location 改写为“线上”，必须失效缓存
+    _invalidatePeriodsCache();
     _grades.add(grade);
     var key = '$semesterId${grade.name}';
     if (_courses.containsKey(key)) {
@@ -366,6 +379,7 @@ class Semester {
   }
 
   void addZjuCalendar(Map<String, dynamic> json) {
+    _invalidatePeriodsCache();
     List<DateTime> startEnd = (json['startEnd'] as List)
         .map((e) => DateTime.parse(e as String))
         .toList();
@@ -430,7 +444,8 @@ class Semester {
   }
 
   void sortExams() {
-    // 考试按开始时间排序
+    // 考试按开始时间排序；顺序影响 periods 尾部考试项，需失效缓存
+    _invalidatePeriodsCache();
     _exams.sort((a, b) => a.time.first.compareTo(b.time.first));
   }
 

--- a/lib/page/calendar/calendar_view.dart
+++ b/lib/page/calendar/calendar_view.dart
@@ -218,21 +218,18 @@ class CalendarPage extends StatelessWidget {
                                 : null),
                       ),
                       Expanded(
-                        child: Obx(
-                          () => ListView(
-                            children: _calendarController
-                                .getEventsForDay(
-                                    _calendarController.selectedDay.value)
-                                .map(
-                                  (e) => Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        vertical: 5, horizontal: 16),
-                                    child: createCard(context, e),
-                                  ),
-                                )
-                                .toList(),
-                          ),
-                        ),
+                        child: Obx(() {
+                          final events = _calendarController.getEventsForDay(
+                              _calendarController.selectedDay.value);
+                          return ListView.builder(
+                            itemCount: events.length,
+                            itemBuilder: (context, index) => Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  vertical: 5, horizontal: 16),
+                              child: createCard(context, events[index]),
+                            ),
+                          );
+                        }),
                       ),
                     ],
                   );

--- a/lib/page/flow/flow_controller.dart
+++ b/lib/page/flow/flow_controller.dart
@@ -20,36 +20,56 @@ class FlowController extends GetxController {
   var _currentScholarFlowCursor = -1;
   var timeNow = DateTime.now().obs;
   final _flowMessenger = FlowMessenger();
+  Timer? _timer;
+  // 数据变化时置位，下一秒执行完整 walk；平时按 _nextWalkAt 的时间边界调度
+  bool _walkPending = false;
+  DateTime _nextWalkAt = DateTime.fromMillisecondsSinceEpoch(0);
+  int _lastFlowSig = 0;
+  DateTime _lastAccrualSaveAt = DateTime.fromMillisecondsSinceEpoch(0);
 
   bool get isDuringFlow => flowList.first.startTime.isBefore(DateTime.now());
 
   @override
   void onInit() {
+    // 把基本事项给排序好，看目前在上哪节课（和排序有关系）
+    refreshScholarFlowList();
     // 按表走，把应用关闭期间的事务项清理掉
     walkFlowList();
     refreshWidget();
 
-    // 每秒刷新，不断更新当前事务的结束时间。当某个事务结束，就把它清理掉。
-    Timer.periodic(const Duration(seconds: 1), (Timer t) {
-      timeNow.value = DateTime.now();
-      walkFlowList();
-    });
-
-    // 把基本事项给排序好，看目前在上哪节课（和排序有关系）
-    _scholarFlowList.sort((a, b) => a.startTime.compareTo(b.startTime));
-    _currentScholarFlowCursor = _scholarFlowList
-        .indexWhere((element) => element.endTime.isAfter(DateTime.now()));
+    // 每秒只更新时钟和进行中的进度；昂贵的完整 walk 只在数据变化或时间边界时执行
+    _timer = Timer.periodic(const Duration(seconds: 1), (Timer t) => _onTick());
 
     // 当“学业”页面有更新（例如出现新课程），更新基本Flow列表
     ever(scholar, (callback) {
       refreshScholarFlowList();
+      _walkPending = true;
       refreshWidget();
     });
     ever(taskList, (callback) {
+      _walkPending = true;
       refreshWidget();
     });
 
     super.onInit();
+  }
+
+  void _onTick() {
+    final now = DateTime.now();
+    timeNow.value = now;
+    if (_walkPending || !now.isBefore(_nextWalkAt)) {
+      _walkPending = false;
+      walkFlowList();
+    } else if (flowList.isNotEmpty && !flowList.first.startTime.isAfter(now)) {
+      // 有事务已开始时，进度累计仍需每秒同步
+      _syncFlowProgress(now);
+    }
+  }
+
+  @override
+  void onClose() {
+    _timer?.cancel();
+    super.onClose();
   }
 
   Future<void> saveFlowListToDb() async {
@@ -67,10 +87,13 @@ class FlowController extends GetxController {
 
   void updateDeadlineListTime() {
     flowListLastUpdate.value = taskListLastUpdate.value.copyWith();
+    // “规划方案已过期”横幅的忽略操作只走这里，需立即持久化，重启后横幅才不会复现
+    _db.setFlowListUpdateTime(flowListLastUpdate.value);
   }
 
   void removeFlowInFlowList() {
     flowList.removeWhere((element) => element.type == PeriodType.flow);
+    _walkPending = true;
   }
 
   // 生成新的安排
@@ -253,8 +276,7 @@ class FlowController extends GetxController {
     });
     updateDeadlineListTime();
     flowList.refresh();
-    _currentScholarFlowCursor =
-        _scholarFlowList.indexWhere((e) => e.endTime.isAfter(DateTime.now()));
+    _refreshScholarCursor();
     walkFlowList();
     refreshWidget();
     return ans.restTime.inMinutes;
@@ -299,38 +321,10 @@ class FlowController extends GetxController {
     });
 
     /* 同步Flow页面的任务进度到Task页面 */
-    for (var i = 0; i < flowList.length; i++) {
-      if (flowList[i].startTime.isAfter(DateTime.now())) break;
-      if (flowList[i].type == PeriodType.flow) {
-        Duration prevProgress =
-            (flowList[i].lastUpdateTime ?? flowList[i].startTime)
-                .difference(flowList[i].startTime);
-        flowList[i].lastUpdateTime = DateTime.now();
-        Duration currProgress =
-            flowList[i].lastUpdateTime!.difference(flowList[i].startTime);
-        Duration length = flowList[i].endTime.difference(flowList[i].startTime);
-
-        if (currProgress <= Duration.zero) break;
-        if (currProgress > length) currProgress = length;
-
-        for (var deadline in taskList) {
-          if (deadline.uid != flowList[i].fromUid) continue;
-          deadline.updateTimeSpent(
-              deadline.timeSpent - prevProgress + currProgress);
-        }
-        taskList.refresh();
-        flowList.refresh();
-      }
-      if (flowList[i].endTime.isBefore(DateTime.now())) {
-        flowList.removeAt(i);
-        i--;
-        flowList.refresh();
-        taskList.refresh();
-      }
-    }
+    _syncFlowProgress(DateTime.now());
 
     /* 重新添加最近48h内的至多5节课程（防止Flow页面太乱）*/
-    refreshScholarFlowList();
+    _refreshScholarCursor();
     if (_currentScholarFlowCursor != -1) {
       for (var i = 0;
           i < 6 && i + _currentScholarFlowCursor < _scholarFlowList.length;
@@ -370,7 +364,88 @@ class FlowController extends GetxController {
       return a.startTime.compareTo(b.startTime);
     });
 
-    saveFlowListToDb();
+    // 内容没变就不写库；lastUpdateTime 的纯累计不算变化，重启后可由墙钟回填
+    final sig = _computeFlowSig();
+    if (sig != _lastFlowSig) {
+      _lastFlowSig = sig;
+      saveFlowListToDb();
+    }
+    _nextWalkAt = _computeNextWalkAt(DateTime.now());
+  }
+
+  /* 同步Flow页面的任务进度到Task页面 */
+  void _syncFlowProgress(DateTime now) {
+    var didAccrue = false;
+    for (var i = 0; i < flowList.length; i++) {
+      if (flowList[i].startTime.isAfter(now)) break;
+      if (flowList[i].type == PeriodType.flow) {
+        Duration prevProgress =
+            (flowList[i].lastUpdateTime ?? flowList[i].startTime)
+                .difference(flowList[i].startTime);
+        flowList[i].lastUpdateTime = now;
+        Duration currProgress =
+            flowList[i].lastUpdateTime!.difference(flowList[i].startTime);
+        Duration length = flowList[i].endTime.difference(flowList[i].startTime);
+
+        if (currProgress <= Duration.zero) break;
+        if (currProgress > length) currProgress = length;
+
+        for (var deadline in taskList) {
+          if (deadline.uid != flowList[i].fromUid) continue;
+          deadline.updateTimeSpent(
+              deadline.timeSpent - prevProgress + currProgress);
+        }
+        didAccrue = true;
+        taskList.refresh();
+        flowList.refresh();
+      }
+      if (flowList[i].endTime.isBefore(now)) {
+        flowList.removeAt(i);
+        i--;
+        flowList.refresh();
+        taskList.refresh();
+        // 跨过了结束边界，下一秒做一次完整 walk（补课程、重算下个边界）
+        _walkPending = true;
+      }
+    }
+    // timeSpent（存于任务表）与 lastUpdateTime（存于规划表）必须成对落盘，
+    // 否则杀进程重启后按墙钟回填会多算或少算，进行中每 15 秒同步一次快照。
+    if (didAccrue &&
+        now.difference(_lastAccrualSaveAt) >= const Duration(seconds: 15)) {
+      _lastAccrualSaveAt = now;
+      saveFlowListToDb();
+      _db.setTaskList(taskList);
+      _db.setTaskListUpdateTime(taskListLastUpdate.value);
+    }
+  }
+
+  int _computeFlowSig() {
+    return Object.hashAll(flowList.map((p) => Object.hash(p.uid, p.type,
+        p.startTime, p.endTime, p.summary, p.location, p.description)));
+  }
+
+  DateTime _computeNextWalkAt(DateTime now) {
+    // 60 秒自愈上限：即使漏枚举了某个边界，最迟一分钟后也会有一次完整 walk
+    var next = now.add(const Duration(seconds: 60));
+    void consider(DateTime t) {
+      if (t.isAfter(now) && t.isBefore(next)) next = t;
+    }
+
+    for (var p in flowList) {
+      consider(p.startTime);
+      consider(p.endTime);
+    }
+    if (_currentScholarFlowCursor != -1) {
+      for (var i = 0;
+          i < 6 && i + _currentScholarFlowCursor < _scholarFlowList.length;
+          i++) {
+        var p = _scholarFlowList[i + _currentScholarFlowCursor];
+        consider(p.endTime);
+        // 距结束 2880 分钟（48 小时）的展示门槛也是一个边界
+        consider(p.endTime.subtract(const Duration(minutes: 2880)));
+      }
+    }
+    return next;
   }
 
   void refreshScholarFlowList() {
@@ -378,11 +453,17 @@ class FlowController extends GetxController {
     _scholarFlowList.sort((a, b) {
       return a.startTime.compareTo(b.startTime);
     });
+    _refreshScholarCursor();
+  }
+
+  void _refreshScholarCursor() {
     _currentScholarFlowCursor =
         _scholarFlowList.indexWhere((e) => e.endTime.isAfter(DateTime.now()));
   }
 
   void refreshWidget() {
+    // 只有 iOS 需要向原生小组件发送数据，其他平台不必构建 DTO
+    if (!Platform.isIOS) return;
     List<PeriodDto?>? flowListDto =
         flowList.where((e) => e.type == PeriodType.flow).map((e) {
       return PeriodDto(

--- a/lib/page/home_page.dart
+++ b/lib/page/home_page.dart
@@ -1,11 +1,10 @@
-import 'dart:async';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart' show Icons;
 import 'package:get/get.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import 'package:celechron/page/scholar/scholar_view.dart';
-import 'package:celechron/page/search/search_view.dart';
 import 'package:celechron/page/flow/flow_view.dart';
 import 'package:celechron/page/task/task_view.dart';
 import 'package:celechron/page/calendar/calendar_view.dart';
@@ -24,124 +23,126 @@ class HomePage extends StatefulWidget {
 
 class _HomePageState extends State<HomePage> {
   int _indexNum = 0;
-  final CupertinoTabController _controller = CupertinoTabController();
-  double _horizontalDragDistance = 0.0; // 跟踪水平拖动距离
+  final PageController _pageController = PageController();
+
+  // 只构建一次，保持各页 widget 身份稳定，切页时不会重跑各页构造器里的 Get.put
+  late final List<Widget> _pages = [
+    _KeepAlivePage(child: FlowPage()),
+    _KeepAlivePage(child: CalendarPage()),
+    _KeepAlivePage(child: TaskPage()),
+    _KeepAlivePage(child: ScholarPage()),
+    _KeepAlivePage(child: OptionPage()),
+  ];
 
   @override
   void initState() {
     super.initState();
-    _controller.index = 0;
     initFuse();
   }
 
-  void changeIndex(int index) {
-    if (_indexNum != index) {
-      setState(() {
-        _indexNum = index;
-        _controller.index = index;
-      });
-    }
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return CupertinoTabScaffold(
-      controller: _controller,
-      tabBuilder: (context, index) => CupertinoTabView(
-        builder: (context) => _getPagesWidget(index),
-      ),
-      tabBar: CupertinoTabBar(
-        iconSize: 26,
-        backgroundColor: CupertinoDynamicColor.resolve(
-                CupertinoColors.secondarySystemBackground, context)
-            .withValues(alpha: 0.5),
-        items: const <BottomNavigationBarItem>[
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.time),
-            label: '接下来',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.calendar),
-            label: '日程',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.check_mark),
-            label: '任务',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.school_rounded),
-            label: '学业',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(CupertinoIcons.settings),
-            label: '设置',
-          ),
-        ],
-        currentIndex: _indexNum,
-        onTap: (int index) {
+    final tabBar = CupertinoTabBar(
+      iconSize: 26,
+      backgroundColor: CupertinoDynamicColor.resolve(
+              CupertinoColors.secondarySystemBackground, context)
+          .withValues(alpha: 0.5),
+      items: const <BottomNavigationBarItem>[
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.time),
+          label: '接下来',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.calendar),
+          label: '日程',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.check_mark),
+          label: '任务',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.school_rounded),
+          label: '学业',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(CupertinoIcons.settings),
+          label: '设置',
+        ),
+      ],
+      currentIndex: _indexNum,
+      // 点按瞬时切换（iOS 原生习惯）。jumpToPage 会同步触发 onPageChanged，
+      // _indexNum 只在 onPageChanged 里更新，这里不再 setState
+      onTap: (int index) => _pageController.jumpToPage(index),
+    );
+
+    final ScrollBehavior scrollBehavior = ScrollConfiguration.of(context);
+    // HeroMode 关闭：原先嵌套 CupertinoTabView 导航器会屏蔽标签页内的 Hero
+    // 飞行动画（如学业页成绩卡片），这里显式关闭以保持原有行为
+    Widget content = HeroMode(
+      enabled: false,
+      child: PageView(
+        controller: _pageController,
+        onPageChanged: (index) {
           if (index != _indexNum) {
             setState(() {
               _indexNum = index;
             });
           }
         },
+        // 允许鼠标拖动切页（与原 GestureDetector 行为一致），只作用于本 PageView，
+        // 不影响页面内部列表；scrollbars 必须关掉，否则桌面端会叠一条横向滚动条
+        scrollBehavior: scrollBehavior.copyWith(
+          scrollbars: false,
+          dragDevices: {
+            ...scrollBehavior.dragDevices,
+            PointerDeviceKind.mouse,
+          },
+        ),
+        children: _pages,
       ),
     );
-  }
 
-  Widget _getPagesWidget(int index) {
-    List<Widget> widgetList = [
-      FlowPage(),
-      CalendarPage(),
-      TaskPage(),
-      ScholarPage(),
-      OptionPage(),
-      SearchPage(), // 缓存一下
-    ];
+    // 以下复刻 CupertinoTabScaffold（resizeToAvoidBottomInset: true）的布局逻辑：
+    // 键盘高度转为内容 Padding 并从子 MediaQuery 移除；本应用标签栏为半透明
+    // （alpha 0.5），栏高只注入 MediaQuery.padding，内容延伸到栏后方由各页
+    // SafeArea 自行避让
+    final MediaQueryData existingMediaQuery = MediaQuery.of(context);
+    MediaQueryData newMediaQuery =
+        existingMediaQuery.removeViewInsets(removeBottom: true);
+    final EdgeInsets contentPadding =
+        EdgeInsets.only(bottom: existingMediaQuery.viewInsets.bottom);
 
-    return Offstage(
-      offstage: _indexNum != index,
-      child: TickerMode(
-        enabled: _indexNum == index,
-        child: GestureDetector(
-          // 使用 onHorizontalDrag 专门处理水平滑动，不会干扰垂直滚动
-          onHorizontalDragStart: (_) {
-            // 初始化拖动距离
-            _horizontalDragDistance = 0.0;
-          },
-          onHorizontalDragUpdate: (details) {
-            // 累积水平拖动距离
-            _horizontalDragDistance += details.delta.dx;
-          },
-          onHorizontalDragEnd: (details) {
-            // 根据滑动速度和距离判断是否切换页面
-            final screenWidth = MediaQuery.of(context).size.width;
-            final velocity = details.primaryVelocity ?? 0;
-            final threshold = screenWidth * 0.15; // 滑动距离阈值（屏幕宽度的15%）
+    // 键盘完全盖住标签栏时不再为栏高留白
+    if (tabBar.preferredSize.height > existingMediaQuery.viewInsets.bottom) {
+      final double bottomPadding =
+          tabBar.preferredSize.height + existingMediaQuery.padding.bottom;
+      newMediaQuery = newMediaQuery.copyWith(
+        padding: newMediaQuery.padding.copyWith(bottom: bottomPadding),
+      );
+    }
 
-            // 向右滑动（显示左侧页面）- 向右滑动意味着显示前一个页面
-            if (velocity > 200 || _horizontalDragDistance > threshold) {
-              if (_indexNum > 0) {
-                changeIndex(_indexNum - 1);
-              }
-            }
-            // 向左滑动（显示右侧页面）- 向左滑动意味着显示后一个页面
-            else if (velocity < -200 || _horizontalDragDistance < -threshold) {
-              if (_indexNum < 4) {
-                changeIndex(_indexNum + 1);
-              }
-            }
-            // 重置状态
-            _horizontalDragDistance = 0.0;
-          },
-          onHorizontalDragCancel: () {
-            // 取消时重置状态
-            _horizontalDragDistance = 0.0;
-          },
-          // 使用 deferToChild 让子组件的垂直滚动优先处理
-          behavior: HitTestBehavior.deferToChild,
-          child: widgetList[index],
-        ),
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: CupertinoTheme.of(context).scaffoldBackgroundColor,
+      ),
+      child: Stack(
+        children: [
+          // 内容在下层，半透明标签栏的 BackdropFilter 才有内容可模糊
+          MediaQuery(
+            data: newMediaQuery,
+            child: Padding(padding: contentPadding, child: content),
+          ),
+          // 标签栏放在修改后的 MediaQuery 之外，读原始 viewPadding 计算安全区
+          MediaQuery.withNoTextScaling(
+            child: Align(alignment: Alignment.bottomCenter, child: tabBar),
+          ),
+        ],
       ),
     );
   }
@@ -179,5 +180,28 @@ class _HomePageState extends State<HomePage> {
             );
           });
     }
+  }
+}
+
+// 离屏页面保活：保留滚动位置等临时状态，等价于原先 CupertinoTabScaffold
+// 对已构建标签页的常驻行为
+class _KeepAlivePage extends StatefulWidget {
+  const _KeepAlivePage({required this.child});
+
+  final Widget child;
+
+  @override
+  State<_KeepAlivePage> createState() => _KeepAlivePageState();
+}
+
+class _KeepAlivePageState extends State<_KeepAlivePage>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
   }
 }

--- a/lib/page/option/login_page.dart
+++ b/lib/page/option/login_page.dart
@@ -97,7 +97,8 @@ class LoginForm extends StatelessWidget {
                             val.password = passwordController.value.text;
                             val.login().then((value) async {
                               if (value.every((e) => e == null)) {
-                                await val.refresh();
+                                await val.refresh(
+                                    onPartialUpdate: scholar.refresh);
                                 scholar.refresh();
                                 buttonPressed.value = false;
                                 _optionController.pushOnGradeChange =

--- a/lib/page/option/option_controller.dart
+++ b/lib/page/option/option_controller.dart
@@ -170,6 +170,13 @@ class OptionController extends GetxController {
     _db.setHideHomeGpa(value);
   }
 
+  bool get asyncRefresh => _option.asyncRefresh.value;
+
+  set asyncRefresh(bool value) {
+    _option.asyncRefresh.value = value;
+    _db.setAsyncRefresh(value);
+  }
+
   String get celechronVersion => _fuse.value.displayVersion;
 
   bool get hasNewVersion => _fuse.value.hasNewVersion;

--- a/lib/page/option/option_view.dart
+++ b/lib/page/option/option_view.dart
@@ -153,6 +153,14 @@ class OptionPage extends StatelessWidget {
                           },
                         ),
                         CupertinoListTile(
+                            title: const Text('异步刷新'),
+                            trailing: Obx(() => CupertinoSwitch(
+                                  value: _optionController.asyncRefresh,
+                                  onChanged: (value) async {
+                                    _optionController.asyncRefresh = value;
+                                  },
+                                ))),
+                        CupertinoListTile(
                             title: const Text('推送成绩变动'),
                             trailing: CupertinoSwitch(
                               value: _optionController.pushOnGradeChange,

--- a/lib/page/scholar/exam_list/exam_list_controller.dart
+++ b/lib/page/scholar/exam_list/exam_list_controller.dart
@@ -10,6 +10,7 @@ class ExamListController extends GetxController {
   final _scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
   late final RxInt semesterIndex;
   final Rx<Duration> _durationToLastUpdate = const Duration().obs;
+  Timer? _timer;
 
   ExamListController({required String initialName}) {
     semesterIndex = semesters.indexWhere((e) => e.name == initialName).obs;
@@ -42,9 +43,15 @@ class ExamListController extends GetxController {
   @override
   void onReady() {
     super.onReady();
-    Timer.periodic(const Duration(seconds: 1), (timer) {
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       _durationToLastUpdate.value =
           DateTime.now().difference(_scholar.value.lastUpdateTimeCourse);
     });
+  }
+
+  @override
+  void onClose() {
+    _timer?.cancel();
+    super.onClose();
   }
 }

--- a/lib/page/scholar/exam_list/exam_list_view.dart
+++ b/lib/page/scholar/exam_list/exam_list_view.dart
@@ -13,13 +13,31 @@ import 'package:celechron/design/custom_colors.dart';
 
 import 'exam_list_controller.dart';
 
-class ExamListPage extends StatelessWidget {
+class ExamListPage extends StatefulWidget {
+  final String initialSemesterName;
+
+  const ExamListPage({required this.initialSemesterName, super.key});
+
+  @override
+  State<ExamListPage> createState() => _ExamListPageState();
+}
+
+class _ExamListPageState extends State<ExamListPage> {
   late final ExamListController _examListController;
 
-  ExamListPage({required String initialSemesterName, super.key}) {
+  @override
+  void initState() {
+    super.initState();
     Get.delete<ExamListController>();
     _examListController =
-        Get.put(ExamListController(initialName: initialSemesterName));
+        Get.put(ExamListController(initialName: widget.initialSemesterName));
+  }
+
+  @override
+  void dispose() {
+    // 离开页面即释放 controller，onClose 里会取消定时器
+    Get.delete<ExamListController>();
+    super.dispose();
   }
 
   Widget _examCard(context, List<Exam> exams) {

--- a/lib/page/scholar/scholar_controller.dart
+++ b/lib/page/scholar/scholar_controller.dart
@@ -18,6 +18,8 @@ class ScholarController extends GetxController {
   // 直接初始化为 0，避免 late final 的初始化时机问题
   final RxInt semesterIndex = 0.obs;
 
+  Timer? _timer;
+
   Scholar get scholar => _scholar.value;
 
   List<Semester> get semesters => _scholar.value.semesters;
@@ -101,7 +103,7 @@ class ScholarController extends GetxController {
         semesters.indexWhere((e) => e.name == _scholar.value.thisSemester.name);
     semesterIndex.value = thisSemesterIndex >= 0 ? thisSemesterIndex : 0;
 
-    Timer.periodic(const Duration(seconds: 1), (timer) {
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       _durationToLastUpdateGrade.value =
           DateTime.now().difference(_scholar.value.lastUpdateTimeGrade);
       _durationToLastUpdateCourse.value =
@@ -109,5 +111,11 @@ class ScholarController extends GetxController {
       _durationToLastUpdateHomework.value =
           DateTime.now().difference(_scholar.value.lastUpdateTimeHomework);
     });
+  }
+
+  @override
+  void onClose() {
+    _timer?.cancel();
+    super.onClose();
   }
 }

--- a/lib/page/scholar/scholar_controller.dart
+++ b/lib/page/scholar/scholar_controller.dart
@@ -165,10 +165,14 @@ class ScholarController extends GetxController {
     if (_activeFetchCount == 1) _startStatusFeed();
     try {
       // 异步刷新开启时，每合并一部分数据就刷新界面和“更新于”时长
-      return await _scholar.value.refresh(onPartialUpdate: () {
-        _scholar.refresh();
-        _updateDurations();
-      }, onFetchStatus: _onFetchStatus).then((value) {
+      return await _scholar.value
+          .refresh(
+              onPartialUpdate: () {
+                _scholar.refresh();
+                _updateDurations();
+              },
+              onFetchStatus: _onFetchStatus)
+          .then((value) {
         _scholar.refresh();
         _updateDurations();
         return value;

--- a/lib/page/scholar/scholar_controller.dart
+++ b/lib/page/scholar/scholar_controller.dart
@@ -81,16 +81,23 @@ class ScholarController extends GetxController {
   List<Todo> get todosInOneWeek =>
       currentSemesterPendingTodos.where((e) => e.isInOneWeek()).toList();
 
-  Future<List<String?>> fetchData() async {
-    return await _scholar.value.refresh().then((value) {
-      _scholar.refresh();
+  void _updateDurations() {
+    _durationToLastUpdateGrade.value =
+        DateTime.now().difference(_scholar.value.lastUpdateTimeGrade);
+    _durationToLastUpdateCourse.value =
+        DateTime.now().difference(_scholar.value.lastUpdateTimeCourse);
+    _durationToLastUpdateHomework.value =
+        DateTime.now().difference(_scholar.value.lastUpdateTimeHomework);
+  }
 
-      _durationToLastUpdateGrade.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeGrade);
-      _durationToLastUpdateCourse.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeCourse);
-      _durationToLastUpdateHomework.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeHomework);
+  Future<List<String?>> fetchData() async {
+    // 异步刷新开启时，每合并一部分数据就刷新界面和“更新于”时长
+    return await _scholar.value.refresh(onPartialUpdate: () {
+      _scholar.refresh();
+      _updateDurations();
+    }).then((value) {
+      _scholar.refresh();
+      _updateDurations();
       return value;
     });
   }
@@ -104,12 +111,7 @@ class ScholarController extends GetxController {
     semesterIndex.value = thisSemesterIndex >= 0 ? thisSemesterIndex : 0;
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      _durationToLastUpdateGrade.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeGrade);
-      _durationToLastUpdateCourse.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeCourse);
-      _durationToLastUpdateHomework.value =
-          DateTime.now().difference(_scholar.value.lastUpdateTimeHomework);
+      _updateDurations();
     });
   }
 

--- a/lib/page/scholar/scholar_controller.dart
+++ b/lib/page/scholar/scholar_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:get/get.dart';
 
+import 'package:celechron/http/spider.dart';
 import 'package:celechron/model/todo.dart';
 import 'package:celechron/model/semester.dart';
 import 'package:celechron/model/scholar.dart';
@@ -19,6 +20,73 @@ class ScholarController extends GetxController {
   final RxInt semesterIndex = 0.obs;
 
   Timer? _timer;
+
+  // —— 刷新状态文案 ——
+  // 刷新超过约 5 秒（第 _statusFirstShowTick 个周期）才开始展示，
+  // 之后每个周期轮换一条；文案基于 Scholar.refresh 上报的真实模块进度
+  static const int _statusFirstShowTick = 2;
+  static const Duration _statusInterval = Duration(milliseconds: 2500);
+
+  // 各抓取模块（本科生与研究生两套标签）的进行中 / 成功 / 失败文案
+  static const Map<String, String> _progressCopy = {
+    '校历': '正在同步校历...',
+    '课表': '正在获取课表...',
+    '考试': '正在解析考试安排...',
+    '成绩': '正在等待成绩数据...',
+    '主修': '正在核对主修成绩...',
+    '作业': '正在同步作业列表...',
+    '实践': '正在统计实践学分...',
+    '配置': '正在同步校历...',
+    '本科生课考试': '正在解析本科生考试...',
+    '本科生课成绩': '正在等待本科生成绩...',
+    '研究生课考试': '正在解析研究生考试...',
+    '研究生课成绩': '正在等待研究生成绩...',
+  };
+  static const Map<String, String> _successCopy = {
+    '校历': '校历已更新',
+    '课表': '成功获取课表',
+    '考试': '成功获取考试安排',
+    '成绩': '成功获取考试成绩',
+    '主修': '主修成绩已更新',
+    '作业': '成功获取作业列表',
+    '实践': '实践学分已更新',
+    '配置': '校历已更新',
+    '本科生课考试': '成功获取本科生考试',
+    '本科生课成绩': '成功获取本科生成绩',
+    '研究生课考试': '成功获取研究生考试',
+    '研究生课成绩': '成功获取研究生成绩',
+  };
+  static const Map<String, String> _failureCopy = {
+    '校历': '校历获取失败',
+    '课表': '课表获取失败',
+    '考试': '考试安排获取失败',
+    '成绩': '成绩获取失败',
+    '主修': '主修成绩获取失败',
+    '作业': '作业获取失败',
+    '实践': '实践学分获取失败',
+    '配置': '校历配置获取失败',
+    '本科生课考试': '本科生考试获取失败',
+    '本科生课成绩': '本科生成绩获取失败',
+    '研究生课考试': '研究生考试获取失败',
+    '研究生课成绩': '研究生成绩获取失败',
+  };
+  // 拿不到任何真实进度（如启动自动刷新占用互斥锁）时的兜底轮播
+  static const List<String> _genericCarousel = [
+    '正在同步教务数据...',
+    '正在等待服务器响应...',
+    '仍在努力获取中...',
+  ];
+
+  /// 当前展示的刷新状态文案，null 表示不展示
+  final Rxn<String> refreshStatusMessage = Rxn<String>();
+
+  Timer? _statusTimer;
+  int _statusTick = 0;
+  int _activeFetchCount = 0;
+  List<ModuleFetchStatus> _statuses = const [];
+  final Map<String, FetchModuleState> _seenStates = {};
+  final List<String> _announcements = [];
+  int _rotation = 0;
 
   Scholar get scholar => _scholar.value;
 
@@ -91,15 +159,81 @@ class ScholarController extends GetxController {
   }
 
   Future<List<String?>> fetchData() async {
-    // 异步刷新开启时，每合并一部分数据就刷新界面和“更新于”时长
-    return await _scholar.value.refresh(onPartialUpdate: () {
-      _scholar.refresh();
-      _updateDurations();
-    }).then((value) {
-      _scholar.refresh();
-      _updateDurations();
-      return value;
-    });
+    // scholar.refresh 内部有互斥，并发的后来者只会空等并返回 []；
+    // 这里计数以保证最后一个调用结束时才收起状态文案
+    _activeFetchCount++;
+    if (_activeFetchCount == 1) _startStatusFeed();
+    try {
+      // 异步刷新开启时，每合并一部分数据就刷新界面和“更新于”时长
+      return await _scholar.value.refresh(onPartialUpdate: () {
+        _scholar.refresh();
+        _updateDurations();
+      }, onFetchStatus: _onFetchStatus).then((value) {
+        _scholar.refresh();
+        _updateDurations();
+        return value;
+      });
+    } finally {
+      _activeFetchCount--;
+      if (_activeFetchCount == 0) _stopStatusFeed();
+    }
+  }
+
+  void _startStatusFeed() {
+    _statusTick = 0;
+    _rotation = 0;
+    _statuses = const [];
+    _seenStates.clear();
+    _announcements.clear();
+    refreshStatusMessage.value = null;
+    _statusTimer?.cancel();
+    _statusTimer = Timer.periodic(_statusInterval, (_) => _onStatusTick());
+  }
+
+  void _stopStatusFeed() {
+    _statusTimer?.cancel();
+    _statusTimer = null;
+    // 置空即收起；展示组件自行缓存末条文案以配合收起动画
+    refreshStatusMessage.value = null;
+  }
+
+  void _onFetchStatus(List<ModuleFetchStatus> statuses) {
+    if (_statusTimer == null) return; // 刷新已结束的迟到回调，忽略
+    _statuses = statuses;
+    // 文案展示开始前就完成的模块不追溯播报
+    var announce = _statusTick >= _statusFirstShowTick;
+    for (var s in statuses) {
+      var prev = _seenStates[s.label];
+      if (announce &&
+          prev == FetchModuleState.pending &&
+          s.state != FetchModuleState.pending) {
+        _announcements.add(s.state == FetchModuleState.success
+            ? _successCopy[s.label] ?? '成功获取${s.label}'
+            : _failureCopy[s.label] ?? '${s.label}获取失败');
+      }
+      _seenStates[s.label] = s.state;
+    }
+  }
+
+  void _onStatusTick() {
+    _statusTick++;
+    if (_statusTick < _statusFirstShowTick) return;
+    if (_announcements.isNotEmpty) {
+      refreshStatusMessage.value = _announcements.removeAt(0);
+      return;
+    }
+    var pending = _statuses
+        .where((s) => s.state == FetchModuleState.pending)
+        .toList(growable: false);
+    if (pending.isNotEmpty) {
+      var label = pending[_rotation++ % pending.length].label;
+      refreshStatusMessage.value = _progressCopy[label] ?? '正在获取$label...';
+    } else if (_statuses.isNotEmpty) {
+      refreshStatusMessage.value = '正在完成刷新...';
+    } else {
+      refreshStatusMessage.value =
+          _genericCarousel[_rotation++ % _genericCarousel.length];
+    }
   }
 
   @override
@@ -118,6 +252,7 @@ class ScholarController extends GetxController {
   @override
   void onClose() {
     _timer?.cancel();
+    _statusTimer?.cancel();
     super.onClose();
   }
 }

--- a/lib/page/scholar/scholar_view.dart
+++ b/lib/page/scholar/scholar_view.dart
@@ -12,6 +12,8 @@ import 'package:celechron/design/two_line_card.dart';
 import 'package:celechron/design/round_rectangle_card.dart';
 import 'package:celechron/design/custom_colors.dart';
 import 'package:celechron/design/animate_button.dart';
+import 'package:celechron/design/refresh_status_indicator.dart';
+import 'package:celechron/design/rolling_shimmer_text.dart';
 
 import 'package:celechron/page/search/search_view.dart';
 import 'course_list/course_list_view.dart';
@@ -871,6 +873,41 @@ class ScholarPage extends StatelessWidget {
                     ),
                   ],
                 ),
+                // 桌面端刷新超过 5 秒后的状态条：小转圈 + 滚动文案，随刷新结束收起。
+                // 移动端的状态文案由下方 CupertinoSliverRefreshControl 的 builder 展示
+                if (PlatformFeatures.isDesktop)
+                  Obx(() {
+                    final message =
+                        _scholarController.refreshStatusMessage.value;
+                    return AnimatedSize(
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeInOut,
+                      alignment: Alignment.topCenter,
+                      // AnimatedSwitcher 让收起时末条文案先淡出、条带再合拢，
+                      // 而不是内容瞬间消失
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 200),
+                        child: message == null
+                            ? const SizedBox(
+                                key: ValueKey('refreshStatusStripEmpty'),
+                                width: double.infinity)
+                            : Padding(
+                                key: const ValueKey('refreshStatusStrip'),
+                                padding:
+                                    const EdgeInsets.only(top: 6, bottom: 2),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    const CupertinoActivityIndicator(radius: 7),
+                                    const SizedBox(width: 6),
+                                    Flexible(
+                                        child: RollingShimmerText(message)),
+                                  ],
+                                ),
+                              ),
+                      ),
+                    );
+                  }),
                 const SizedBox(height: 4),
                 Divider(
                   thickness: 0,
@@ -882,6 +919,18 @@ class ScholarPage extends StatelessWidget {
         )),
         if (_scholarController.scholar.isLogan)
           CupertinoSliverRefreshControl(
+            // 复刻原生转圈，刷新超过 5 秒后在其右侧滚动展示状态文案。
+            // Obx 是必需的：刷新驻留期间 sliver 高度不变、builder 不会被重调，
+            // 文案更新只能靠响应式重建
+            builder: (context, refreshState, pulledExtent,
+                    refreshTriggerPullDistance, refreshIndicatorExtent) =>
+                Obx(() => RefreshStatusIndicator(
+                      refreshState: refreshState,
+                      pulledExtent: pulledExtent,
+                      refreshTriggerPullDistance: refreshTriggerPullDistance,
+                      refreshIndicatorExtent: refreshIndicatorExtent,
+                      message: _scholarController.refreshStatusMessage.value,
+                    )),
             onRefresh: () async {
               var error = await _scholarController.fetchData();
               if (error.any((e) => e != null)) {

--- a/lib/page/scholar/scholar_view.dart
+++ b/lib/page/scholar/scholar_view.dart
@@ -3,6 +3,7 @@ import 'package:celechron/page/scholar/todo/todo_card.dart';
 import 'package:celechron/utils/platform_features.dart';
 import 'package:extended_sliver/extended_sliver.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -93,6 +94,22 @@ class ScholarPage extends StatelessWidget {
 
   final _scholarController = Get.put(ScholarController());
   final ValueNotifier<bool> _isRefreshing = ValueNotifier(false);
+
+  // 让页内横向列表在桌面端也响应鼠标拖动。外层 PageView 为支持鼠标切页开启了
+  // 鼠标拖动，横向列表若不响应鼠标，拖动会漏到 PageView 上造成误切页；
+  // 内层可滚动组件在手势竞技中优先，包上后拖动由列表自己消费（触屏行为不变）
+  Widget _mouseDraggable(BuildContext context, Widget child) {
+    return ScrollConfiguration(
+      behavior: ScrollConfiguration.of(context).copyWith(
+        scrollbars: false,
+        dragDevices: {
+          ...ScrollConfiguration.of(context).dragDevices,
+          PointerDeviceKind.mouse,
+        },
+      ),
+      child: child,
+    );
+  }
 
   Widget _buildGradeBrief(BuildContext context) {
     final optionController =
@@ -578,19 +595,21 @@ class ScholarPage extends StatelessWidget {
                             if (_scholarController.todos.isNotEmpty)
                               SizedBox(
                                   height: 102,
-                                  child: ListView.separated(
-                                      scrollDirection: Axis.horizontal,
-                                      itemCount:
-                                          _scholarController.todos.length,
-                                      separatorBuilder: (context, index) =>
-                                          const SizedBox(width: 8),
-                                      itemBuilder: (context, index) {
-                                        final todo =
-                                            _scholarController.todos[index];
-                                        return SizedBox(
-                                            width: 200,
-                                            child: TodoCard(todo: todo));
-                                      }))
+                                  child: _mouseDraggable(
+                                      context,
+                                      ListView.separated(
+                                          scrollDirection: Axis.horizontal,
+                                          itemCount:
+                                              _scholarController.todos.length,
+                                          separatorBuilder: (context, index) =>
+                                              const SizedBox(width: 8),
+                                          itemBuilder: (context, index) {
+                                            final todo =
+                                                _scholarController.todos[index];
+                                            return SizedBox(
+                                                width: 200,
+                                                child: TodoCard(todo: todo));
+                                          })))
                           ],
                         ))),
               ],
@@ -837,36 +856,39 @@ class ScholarPage extends StatelessWidget {
                     Expanded(
                       child: SizedBox(
                         height: 30,
-                        child: Obx(
-                          () => ListView.builder(
-                            scrollDirection: Axis.horizontal,
-                            itemCount: _scholarController.semesters.length,
-                            itemBuilder: (context, index) {
-                              final semester =
-                                  _scholarController.semesters[index];
-                              return Stack(
-                                children: [
-                                  Obx(
-                                    () => AnimateButton(
-                                      text:
-                                          '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}',
-                                      onTap: () {
-                                        _scholarController.semesterIndex.value =
-                                            index;
-                                        _scholarController.semesterIndex
-                                            .refresh();
-                                      },
-                                      backgroundColor: _scholarController
-                                                  .semesterIndex.value ==
-                                              index
-                                          ? CustomCupertinoDynamicColors.cyan
-                                          : CupertinoColors.systemFill,
+                        child: _mouseDraggable(
+                          context,
+                          Obx(
+                            () => ListView.builder(
+                              scrollDirection: Axis.horizontal,
+                              itemCount: _scholarController.semesters.length,
+                              itemBuilder: (context, index) {
+                                final semester =
+                                    _scholarController.semesters[index];
+                                return Stack(
+                                  children: [
+                                    Obx(
+                                      () => AnimateButton(
+                                        text:
+                                            '${semester.name.substring(2, 5)}${semester.name.substring(7, 11)}',
+                                        onTap: () {
+                                          _scholarController
+                                              .semesterIndex.value = index;
+                                          _scholarController.semesterIndex
+                                              .refresh();
+                                        },
+                                        backgroundColor: _scholarController
+                                                    .semesterIndex.value ==
+                                                index
+                                            ? CustomCupertinoDynamicColors.cyan
+                                            : CupertinoColors.systemFill,
+                                      ),
                                     ),
-                                  ),
-                                  const SizedBox(width: 90),
-                                ],
-                              );
-                            },
+                                    const SizedBox(width: 90),
+                                  ],
+                                );
+                              },
+                            ),
                           ),
                         ),
                       ),

--- a/lib/page/task/task_controller.dart
+++ b/lib/page/task/task_controller.dart
@@ -7,6 +7,7 @@ class TaskController extends GetxController {
   final taskList = Get.find<RxList<Task>>(tag: 'taskList');
   final taskListLastUpdate = Get.find<Rx<DateTime>>(tag: 'taskListLastUpdate');
   final _db = Get.find<DatabaseHelper>(tag: 'db');
+  Timer? _timer;
 
   List<Task> get todoDeadlineList => taskList
       .where((element) => (element.type == TaskType.deadline &&
@@ -26,16 +27,16 @@ class TaskController extends GetxController {
   @override
   void onInit() {
     updateDeadlineList();
-    Timer.periodic(const Duration(seconds: 1), (Timer t) {
+    _timer = Timer.periodic(const Duration(seconds: 1), (Timer t) {
       updateDeadlineList();
-      refreshDeadlineList();
     });
     super.onInit();
   }
 
-  void refreshDeadlineList() {
-    saveDeadlineListToDb();
-    //print('TaskListPage: refreshed');
+  @override
+  void onClose() {
+    _timer?.cancel();
+    super.onClose();
   }
 
   Future<void> saveDeadlineListToDb() async {
@@ -49,14 +50,25 @@ class TaskController extends GetxController {
 
   void updateDeadlineListTime() {
     taskListLastUpdate.value = DateTime.now();
+    // 所有改字段不改列表结构的用户操作（标记完成、暂停/继续等）都经过这里，即时落盘
+    saveDeadlineListToDb();
   }
 
-  void updateDeadlineList() {
-    taskList.removeWhere((element) => element.status == TaskStatus.deleted);
+  /// 刷新任务状态（过期判定、固定日程滚动等）。返回是否有数据变化。
+  /// 只在真正有变化时执行 RxList 操作和写库，避免每秒空转通知 UI、全量写 Hive。
+  bool updateDeadlineList() {
+    var changed = false;
+
+    if (taskList.any((element) => element.status == TaskStatus.deleted)) {
+      taskList.removeWhere((element) => element.status == TaskStatus.deleted);
+      changed = true;
+    }
 
     Set<String> existingUid = {};
     List<Task> newDeadlineList = [];
     for (var deadline in taskList) {
+      final oldStatus = deadline.status;
+      final oldEndTime = deadline.endTime;
       deadline.refreshStatus();
       if (deadline.type == TaskType.deadline) {
         if (deadline.timeSpent >= deadline.timeNeeded) {
@@ -84,25 +96,57 @@ class TaskController extends GetxController {
           }
         }
       }
+      if (deadline.status != oldStatus || deadline.endTime != oldEndTime) {
+        changed = true;
+      }
     }
-    taskList.addAll(newDeadlineList);
-    taskList.removeWhere((element) =>
+    if (newDeadlineList.isNotEmpty) {
+      taskList.addAll(newDeadlineList);
+      changed = true;
+    }
+    if (taskList.any((element) =>
         element.type == TaskType.fixedlegacy &&
-        !existingUid.contains(element.fromUid));
+        !existingUid.contains(element.fromUid))) {
+      taskList.removeWhere((element) =>
+          element.type == TaskType.fixedlegacy &&
+          !existingUid.contains(element.fromUid));
+      changed = true;
+    }
 
-    taskList.sort((a, b) => a.endTime.compareTo(b.endTime));
+    // 视图可能直接 taskList.add 了新任务或改了 endTime，用顺序守卫兜底
+    if (!changed) {
+      changed = !_isSortedByEndTime();
+    }
+
+    if (changed) {
+      // sort 无条件通知，兼作纯状态翻转（无 RxList 结构操作）时的 UI 通知
+      taskList.sort((a, b) => a.endTime.compareTo(b.endTime));
+      saveDeadlineListToDb();
+    }
+    return changed;
+  }
+
+  bool _isSortedByEndTime() {
+    for (var i = 1; i < taskList.length; i++) {
+      if (taskList[i - 1].endTime.isAfter(taskList[i].endTime)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   void removeCompletedDeadline(context) {
     taskList.removeWhere((element) =>
         element.type == TaskType.deadline &&
         element.status == TaskStatus.completed);
+    saveDeadlineListToDb();
   }
 
   void removeFailedDeadline(context) {
     taskList.removeWhere((element) =>
         element.type == TaskType.deadline &&
         element.status == TaskStatus.failed);
+    saveDeadlineListToDb();
   }
 
   int suspendAllDeadline(context) {

--- a/lib/page/task/task_view.dart
+++ b/lib/page/task/task_view.dart
@@ -292,7 +292,7 @@ class TaskPage extends StatelessWidget {
           child: RoundRectangleCard(
             onTap: () async {
               // 直接导航到编辑页面
-              Task? res = await Navigator.of(context).push(
+              Task? res = await Navigator.of(context, rootNavigator: true).push(
                 CupertinoPageRoute(
                   builder: (context) => TaskEditPage(deadline),
                 ),

--- a/lib/page/task/task_view.dart
+++ b/lib/page/task/task_view.dart
@@ -126,6 +126,8 @@ class TaskPage extends StatelessWidget {
                     _taskController.updateDeadlineListTime();
                   }
                   _taskController.taskList.refresh();
+                  // 仅改 summary 等字段时 updateDeadlineList 检测不到变化，需显式落盘
+                  _taskController.saveDeadlineListToDb();
                 },
                 child: const Text('编辑'),
               ),
@@ -336,22 +338,26 @@ class TaskPage extends StatelessWidget {
                                     overflow: TextOverflow.ellipsis,
                                   ))),
                       const Spacer(),
-                      Text(
-                          deadline.type == TaskType.deadline
-                              ? deadlineStatusName[deadline.status]!
-                              : (DateTime.now().isBefore(deadline.startTime)
-                                  ? '未开始'
-                                  : (!DateTime.now().isBefore(deadline.endTime)
-                                      ? '已结束'
-                                      : '进行中')),
-                          style: CupertinoTheme.of(context)
-                              .textTheme
-                              .textStyle
-                              .copyWith(
-                                fontSize: 14,
-                                fontWeight: FontWeight.bold,
-                                overflow: TextOverflow.ellipsis,
-                              )),
+                      // 固定日程的状态随时间翻转；taskList 不再每秒通知，改由 timeNow 驱动
+                      Obx(() {
+                        final now = _flowController.timeNow.value;
+                        return Text(
+                            deadline.type == TaskType.deadline
+                                ? deadlineStatusName[deadline.status]!
+                                : (now.isBefore(deadline.startTime)
+                                    ? '未开始'
+                                    : (!now.isBefore(deadline.endTime)
+                                        ? '已结束'
+                                        : '进行中')),
+                            style: CupertinoTheme.of(context)
+                                .textTheme
+                                .textStyle
+                                .copyWith(
+                                  fontSize: 14,
+                                  fontWeight: FontWeight.bold,
+                                  overflow: TextOverflow.ellipsis,
+                                ));
+                      }),
                     ],
                   ),
                   const SizedBox(height: 8.0),
@@ -467,12 +473,16 @@ class TaskPage extends StatelessWidget {
                   if (deadline.type == TaskType.fixed ||
                       deadline.status == TaskStatus.running) ...[
                     const SizedBox(height: 8.0),
-                    LinearProgressIndicator(
-                      value: progress,
-                      backgroundColor: CupertinoDynamicColor.resolve(
-                          CupertinoColors.separator, context),
-                      valueColor: AlwaysStoppedAnimation<Color>(color),
-                    ),
+                    // 固定日程的进度随时间前进，订阅 timeNow 以便每秒刷新
+                    Obx(() {
+                      final _ = _flowController.timeNow.value;
+                      return LinearProgressIndicator(
+                        value: deadline.getProgress(),
+                        backgroundColor: CupertinoDynamicColor.resolve(
+                            CupertinoColors.separator, context),
+                        valueColor: AlwaysStoppedAnimation<Color>(color),
+                      );
+                    }),
                   ],
                   if (deadline.type == TaskType.deadline &&
                       deadline.status == TaskStatus.suspended) ...[

--- a/test/refresh_status_test.dart
+++ b/test/refresh_status_test.dart
@@ -33,9 +33,13 @@ void main() {
       final statuses = moduleStatusesFromErrors(
           [null, null, '考试查询出错：500', null, null, null, null], labels);
       expect(
-          statuses.where((s) => s.state == FetchModuleState.failed).single.label,
+          statuses
+              .where((s) => s.state == FetchModuleState.failed)
+              .single
+              .label,
           '考试');
-      expect(statuses.where((s) => s.state == FetchModuleState.pending), isEmpty);
+      expect(
+          statuses.where((s) => s.state == FetchModuleState.pending), isEmpty);
     });
 
     test('长度不一致时视为不可信，返回空列表（如 MockSpider 的 6 项错误表）', () {

--- a/test/refresh_status_test.dart
+++ b/test/refresh_status_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:celechron/http/spider.dart';
+
+void main() {
+  group('moduleStatusesFromErrors', () {
+    const labels = ['校历', '课表', '考试', '成绩', '主修', '作业', '实践'];
+
+    test('null 为成功、「查询进行中」为进行中、其余为失败，且按下标对应标签', () {
+      final statuses = moduleStatusesFromErrors([
+        null,
+        '课表查询进行中',
+        '考试查询出错：Connection closed',
+        null,
+        '主修查询进行中',
+        '作业查询出错：超时',
+        '实践查询进行中',
+      ], labels);
+
+      expect(statuses, hasLength(7));
+      expect(statuses[0].label, '校历');
+      expect(statuses[0].state, FetchModuleState.success);
+      expect(statuses[1].state, FetchModuleState.pending);
+      expect(statuses[2].state, FetchModuleState.failed);
+      expect(statuses[3].state, FetchModuleState.success);
+      expect(statuses[4].state, FetchModuleState.pending);
+      expect(statuses[5].state, FetchModuleState.failed);
+      expect(statuses[6].label, '实践');
+      expect(statuses[6].state, FetchModuleState.pending);
+    });
+
+    test('最终态（无「查询进行中」标记）只区分成功与失败', () {
+      final statuses = moduleStatusesFromErrors(
+          [null, null, '考试查询出错：500', null, null, null, null], labels);
+      expect(
+          statuses.where((s) => s.state == FetchModuleState.failed).single.label,
+          '考试');
+      expect(statuses.where((s) => s.state == FetchModuleState.pending), isEmpty);
+    });
+
+    test('长度不一致时视为不可信，返回空列表（如 MockSpider 的 6 项错误表）', () {
+      final statuses = moduleStatusesFromErrors(
+          [null, null, null, null, null, null], labels);
+      expect(statuses, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
在这个学期的使用中，我感觉到每次刷新的速度有些低，因此我尝试使用了**claude fable 5**模型来协助修改，主要为了提高这个项目的单词刷新速度并尝试使用缓存以减少项目获取的数据。此外，我还尝试添加了刷新动画、页面切换动画，希望可以为您的团队提供参考



## 1. 修复会话过期后刷新失败不自动重试（8316b74）

- 修正本科生 Spider 可重试错误匹配串的笔误（`wisportalid` → `iplanetdirectorypro`），SSO 过期后现在能正确触发重新登录并重试。
- 学在浙大：无法获取 session、教务网：会话已过期 纳入可重试错误，过期后自动重登恢复。
- 服务层（zdbk / grs_new / courses）增加会话过期检测与自动重登，失败时回退本地缓存数据，不清空已有学业数据。
- `HttpClient` 增加 5 秒连接超时，断网 / 服务器不可达时快速失败；重试次数 2→1、间隔 1s→300ms，缩短失败场景的等待时间。

## 2. 空闲性能优化（4d18af3）

- Task 页定时器改为变更检测：仅在状态翻转、固定日程滚动、增删或排序变化时才通知 UI 并写 Hive；用户编辑路径全部即时落盘。
- Flow 页定时器每秒只更新时钟与进行中进度，完整 walk 改为数据变化或时间边界触发（60 秒自愈上限），写库由内容签名门控。
- 任务进行中时 `timeSpent` 与 `lastUpdateTime` 每 15 秒成对落盘，保证杀进程重启后按墙钟回填一致。
- 修复 4 处 `Timer.periodic` 从不 cancel 的泄漏；`ExamListPage` 改为 StatefulWidget，离开页面即释放 controller。
- `Semester.periods` 加缓存，所有影响构建输入的 mutator 均失效缓存；两个 Spider 的校历 JSON 解码从每块 5 次降为 1 次。
- 日历页事件列表改用 `ListView.builder` 按需构建；`refreshWidget` 在非 iOS 平台直接返回。

## 3. 异步刷新与进度反馈（a43d91a、cf10a1e）

- `Scholar.refresh()` 支持 `onPartialUpdate`：开启「异步刷新」选项后，各板块抓取成功即合并进内存并立即更新面板数据与「更新于」时间戳，无需等全部抓取完成。学期 / 校历特殊日期仅在其全部来源抓取成功后合并，最终的完整合并、持久化与错误上报与同步模式完全一致；后台刷新不传回调，行为不变。
- 学业页刷新超过 5 秒后，在转圈旁滚动显示各模块抓取进度文案（如「成功获取考试成绩」），成功 / 失败播报优先于进行中轮换；桌面端在学期栏下方以可收放状态条展示。状态上报与数据合并解耦，不受异步刷新开关影响。
- 新增 `RollingShimmerText` 流光文字组件（`ShaderMask` 实现，深浅色自适应，零新依赖）；新增 `moduleStatusesFromErrors` 纯逻辑单测（`test/refresh_status_test.dart`）。

## 4. 主页切页交互重做（42dcce7、cd23b1f）

- 用 `PageView` 替换 `CupertinoTabScaffold` + 手动手势检测：滑动跟手、松手吸附，拖动过半时标签高亮同步切换；离屏页面保活（滚动位置等状态保留），复刻了半透明标签栏的底部避让与键盘处理逻辑。
- 桌面端支持鼠标拖动切页；学期选择栏与作业卡片等内层横向列表优先消费拖动手势，不再误触外层切页；触屏行为不变。
- 任务编辑页改为全屏推入（rootNavigator），与其他详情页一致，Android 返回键可正确关闭。

## 杂项

- 删除误提交的截图文件 `flutter_01.png`（4b7256c）。
- `dart format` 全量格式化（580ef04）。

## 验证
- `flutter analyze` 没有新增问题
- 用我自己的账号测试了几天，比原来刷新速度有较明显提高，体验更丝滑