### PR TITLE
feat: iOS 日历地址映射

### DIFF
--- a/lib/model/calendar_to_ical.dart
+++ b/lib/model/calendar_to_ical.dart
@@ -4,6 +4,7 @@ import 'package:crypto/crypto.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:celechron/model/location_mapper.dart';
 import 'package:celechron/model/period.dart';
 import 'package:celechron/model/scholar.dart';
 import 'package:celechron/model/semester.dart';
@@ -51,6 +52,8 @@ class CalendarToIcal {
         '${DateTime.now().toUtc().toIso8601String().replaceAll(RegExp(r'[-:]'), '').split('.')[0]}Z';
     final startStr = _toISOString(period.startTime);
     final endStr = _toISOString(period.endTime);
+    final mappedLocation =
+        CalendarLocationMapper.mapForCalendar(period.location);
 
     // 生成唯一ID
     final hash = _generateHash(period);
@@ -76,8 +79,8 @@ class CalendarToIcal {
     buffer.writeln('LAST-MODIFIED:$utcStr');
 
     // 地点信息
-    if (period.location.isNotEmpty) {
-      buffer.writeln('LOCATION:${period.location}');
+    if (mappedLocation.isNotEmpty) {
+      buffer.writeln('LOCATION:$mappedLocation');
     }
 
     buffer.writeln('SEQUENCE:0');
@@ -99,8 +102,10 @@ class CalendarToIcal {
 
   /// 生成事件的哈希ID
   static String _generateHash(Period period) {
+    final mappedLocation =
+        CalendarLocationMapper.mapForCalendar(period.location);
     final content =
-        '${period.description}${period.summary}${period.location}${_toISOString(period.startTime)}';
+        '${period.description}${period.summary}$mappedLocation${_toISOString(period.startTime)}';
     final bytes = utf8.encode(content);
     final digest = sha1.convert(bytes);
     return digest.toString();

--- a/lib/model/calendar_to_system.dart
+++ b/lib/model/calendar_to_system.dart
@@ -4,6 +4,7 @@ import 'package:device_calendar/device_calendar.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
 import 'package:timezone/timezone.dart' as tz;
+import 'package:celechron/model/location_mapper.dart';
 import 'package:celechron/model/scholar.dart';
 import 'package:celechron/model/period.dart';
 import 'package:celechron/model/semester.dart';
@@ -239,8 +240,10 @@ class CalendarToSystemManager {
         tz.TZDateTime.from(period.endTime, tz.getLocation('Asia/Shanghai'));
 
     // 设置地点
-    if (period.location.isNotEmpty) {
-      event.location = period.location;
+    final mappedLocation =
+        CalendarLocationMapper.mapForCalendar(period.location);
+    if (mappedLocation.isNotEmpty) {
+      event.location = mappedLocation;
     }
 
     // 根据类型设置不同的属性
@@ -264,9 +267,11 @@ class CalendarToSystemManager {
   /// 生成事件的唯一标识符
   /// 基于期间的关键信息生成，确保相同的课程不会重复添加
   String _generateEventId(Period period) {
+    final mappedLocation =
+        CalendarLocationMapper.mapForCalendar(period.location);
     // 使用摘要、开始时间、结束时间和地点生成唯一ID
     var key =
-        '${period.summary}_${period.startTime.toIso8601String()}_${period.endTime.toIso8601String()}_${period.location}';
+        '${period.summary}_${period.startTime.toIso8601String()}_${period.endTime.toIso8601String()}_$mappedLocation';
     return key.hashCode.toString();
   }
 

--- a/lib/model/location_mapper.dart
+++ b/lib/model/location_mapper.dart
@@ -25,7 +25,7 @@ class BuildingAlias {
 ///
 /// 教务网中的地址规范为：[校区+教学楼]-[教室]，如"紫金港西1-101"表示"紫金港西1教学楼-101教室"，详细地址为"浙江大学紫金港校区西一教学楼"。
 /// 映射输出格式：原始文本, 具体楼宇地址
-/// 例如："紫金港西1-101" → "紫金港西1-101, 浙江大学紫金港校区西一教学楼-101"
+/// 例如："紫金港西1-101" → "紫金港西1-101, 浙江大学紫金港校区西一教学楼"
 ///
 /// 可能存在不包含'-'符号的地址，目前已知存在这种情况的地址较少，且定位较为准确，因此可以直接保留原始字符串。
 class CalendarLocationMapper {
@@ -63,15 +63,15 @@ class CalendarLocationMapper {
     // 其他
     BuildingAlias(campusName: '紫金港', aliases: ['蒙民伟'], fullName: '蒙民伟楼'),
 
-    // todo: 玉泉
+    // TODO: 玉泉
 
-    // todo: 西溪
+    // TODO: 西溪
 
-    // todo: 华家池
+    // TODO: 华家池
 
-    // todo: 之江
+    // TODO: 之江
 
-    // todo: 海宁
+    // TODO: 海宁
   ];
 
   static String mapForCalendar(String? rawLocation) {
@@ -88,12 +88,11 @@ class CalendarLocationMapper {
       mappedAddress = _mapHeadToFullAddress(normalized);
     } else {
       final head = parts.$1;
-      final room = parts.$2;
       if (head.isEmpty) return raw;
 
       final mappedHead = _mapHeadToFullAddress(head);
       if (mappedHead != null) {
-        mappedAddress = room.isEmpty ? mappedHead : '$mappedHead-$room';
+        mappedAddress = mappedHead;
       }
     }
 

--- a/lib/model/location_mapper.dart
+++ b/lib/model/location_mapper.dart
@@ -23,14 +23,11 @@ class BuildingAlias {
 /// 日历地点映射器
 /// 将 zdbk 中的上课地址缩写转换为详细地址，避免日历/地图定位失败。
 ///
-/// 教务网中的地址规范为：[校区+教学楼]-[教室]，如“紫金港西1-101”表示“紫金港西1教学楼-101教室”，详细地址为“浙江大学紫金港校区西一教学楼”（根据apple地图）
-/// 映射实现方式（暂定）：
-/// 1. 定位字符串中的'-'符号，将其前后部分分开
-/// 2. 前半部分（如“紫金港西1”）进行教学楼的解析，转换成更详细的描述（如“浙江大学紫金港校区西一教学楼”）
-/// 3. 后半部分（如“101”）直接保留
-/// 4. 最终组合成完整的地址字符串（如“浙江大学紫金港校区西一教学楼-101”）
-/// 
-/// 可能存在不包含'-'符号的地址，目前已知存在这种情况的地址较少，且定位较为准确，因此可以直接保留原始字符串
+/// 教务网中的地址规范为：[校区+教学楼]-[教室]，如"紫金港西1-101"表示"紫金港西1教学楼-101教室"，详细地址为"浙江大学紫金港校区西一教学楼"。
+/// 映射输出格式：原始文本, 具体楼宇地址
+/// 例如："紫金港西1-101" → "紫金港西1-101, 浙江大学紫金港校区西一教学楼-101"
+///
+/// 可能存在不包含'-'符号的地址，目前已知存在这种情况的地址较少，且定位较为准确，因此可以直接保留原始字符串。
 class CalendarLocationMapper {
   static const List<CampusAlias> _campusAliases = [
     CampusAlias(campusName: '紫金港', aliases: ['紫金港']),
@@ -43,7 +40,7 @@ class CalendarLocationMapper {
   /// 楼宇映射表：后续按这个数组持续补充即可。
   static const List<BuildingAlias> _buildingAliases = [
     // 紫金港
-      // 东教
+    // 东教
     BuildingAlias(campusName: '紫金港', aliases: ['东1'], fullName: '东一教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['东1A'], fullName: '东一教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['东1B'], fullName: '东一教学楼'),
@@ -52,25 +49,29 @@ class CalendarLocationMapper {
     BuildingAlias(campusName: '紫金港', aliases: ['东4'], fullName: '东四教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['东5'], fullName: '东五教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['东6'], fullName: '东六教学楼'),
-      // 西教
+    // 西教
     BuildingAlias(campusName: '紫金港', aliases: ['西1'], fullName: '西一教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['西2'], fullName: '西二教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['西3'], fullName: '西三教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['西3A'], fullName: '西三教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['西3B'], fullName: '西三教学楼'),
-      // 北教
+    // 北教
     BuildingAlias(campusName: '紫金港', aliases: ['北1'], fullName: '北一教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['北2'], fullName: '北二教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['北3'], fullName: '北三教学楼'),
     BuildingAlias(campusName: '紫金港', aliases: ['北4'], fullName: '北四教学楼'),
-      // 其他
+    // 其他
     BuildingAlias(campusName: '紫金港', aliases: ['蒙民伟'], fullName: '蒙民伟楼'),
 
-    // 玉泉
-    BuildingAlias(campusName: '玉泉', aliases: ['教1'], fullName: '第一教学楼'),
-    BuildingAlias(campusName: '玉泉', aliases: ['教2'], fullName: '第二教学楼'),
-    BuildingAlias(campusName: '玉泉', aliases: ['教3'], fullName: '第三教学楼'),
-    BuildingAlias(campusName: '玉泉', aliases: ['教4'], fullName: '第四教学楼'),
+    // todo: 玉泉
+
+    // todo: 西溪
+
+    // todo: 华家池
+
+    // todo: 之江
+
+    // todo: 海宁
   ];
 
   static String mapForCalendar(String? rawLocation) {
@@ -80,23 +81,24 @@ class CalendarLocationMapper {
 
     final normalized = _normalizeDash(raw);
     final parts = _splitHeadAndRoom(normalized);
+
+    String? mappedAddress;
     if (parts == null) {
-      return _mapWithoutRoom(normalized);
+      // 无房间号，直接映射整体
+      mappedAddress = _mapHeadToFullAddress(normalized);
+    } else {
+      final head = parts.$1;
+      final room = parts.$2;
+      if (head.isEmpty) return raw;
+
+      final mappedHead = _mapHeadToFullAddress(head);
+      if (mappedHead != null) {
+        mappedAddress = room.isEmpty ? mappedHead : '$mappedHead-$room';
+      }
     }
 
-    final head = parts.$1;
-    final room = parts.$2;
-    if (head.isEmpty) return raw;
-
-    final mappedHead = _mapHeadToFullAddress(head);
-    if (mappedHead == null) return raw;
-    if (room.isEmpty) return mappedHead;
-    return '$mappedHead-$room';
-  }
-
-  static String _mapWithoutRoom(String raw) {
-    final mappedHead = _mapHeadToFullAddress(raw);
-    return mappedHead ?? raw;
+    if (mappedAddress == null) return raw;
+    return '$normalized, $mappedAddress';
   }
 
   static String? _mapHeadToFullAddress(String head) {

--- a/lib/model/location_mapper.dart
+++ b/lib/model/location_mapper.dart
@@ -1,0 +1,158 @@
+class CampusAlias {
+  final String campusName;
+  final List<String> aliases;
+
+  const CampusAlias({
+    required this.campusName,
+    required this.aliases,
+  });
+}
+
+class BuildingAlias {
+  final String? campusName;
+  final List<String> aliases;
+  final String fullName;
+
+  const BuildingAlias({
+    this.campusName,
+    required this.aliases,
+    required this.fullName,
+  });
+}
+
+/// 日历地点映射器
+/// 将 zdbk 中的上课地址缩写转换为详细地址，避免日历/地图定位失败。
+///
+/// 教务网中的地址规范为：[校区+教学楼]-[教室]，如“紫金港西1-101”表示“紫金港西1教学楼-101教室”，详细地址为“浙江大学紫金港校区西一教学楼”（根据apple地图）
+/// 映射实现方式（暂定）：
+/// 1. 定位字符串中的'-'符号，将其前后部分分开
+/// 2. 前半部分（如“紫金港西1”）进行教学楼的解析，转换成更详细的描述（如“浙江大学紫金港校区西一教学楼”）
+/// 3. 后半部分（如“101”）直接保留
+/// 4. 最终组合成完整的地址字符串（如“浙江大学紫金港校区西一教学楼-101”）
+/// 
+/// 可能存在不包含'-'符号的地址，目前已知存在这种情况的地址较少，且定位较为准确，因此可以直接保留原始字符串
+class CalendarLocationMapper {
+  static const List<CampusAlias> _campusAliases = [
+    CampusAlias(campusName: '紫金港', aliases: ['紫金港']),
+    CampusAlias(campusName: '玉泉', aliases: ['玉泉']),
+    CampusAlias(campusName: '西溪', aliases: ['西溪']),
+    CampusAlias(campusName: '华家池', aliases: ['华家池']),
+    CampusAlias(campusName: '之江', aliases: ['之江']),
+  ];
+
+  /// 楼宇映射表：后续按这个数组持续补充即可。
+  static const List<BuildingAlias> _buildingAliases = [
+    // 紫金港
+      // 东教
+    BuildingAlias(campusName: '紫金港', aliases: ['东1'], fullName: '东一教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东1A'], fullName: '东一教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东1B'], fullName: '东一教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东2'], fullName: '东二教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东3'], fullName: '东三教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东4'], fullName: '东四教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东5'], fullName: '东五教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['东6'], fullName: '东六教学楼'),
+      // 西教
+    BuildingAlias(campusName: '紫金港', aliases: ['西1'], fullName: '西一教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['西2'], fullName: '西二教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['西3'], fullName: '西三教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['西3A'], fullName: '西三教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['西3B'], fullName: '西三教学楼'),
+      // 北教
+    BuildingAlias(campusName: '紫金港', aliases: ['北1'], fullName: '北一教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['北2'], fullName: '北二教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['北3'], fullName: '北三教学楼'),
+    BuildingAlias(campusName: '紫金港', aliases: ['北4'], fullName: '北四教学楼'),
+      // 其他
+    BuildingAlias(campusName: '紫金港', aliases: ['蒙民伟'], fullName: '蒙民伟楼'),
+
+    // 玉泉
+    BuildingAlias(campusName: '玉泉', aliases: ['教1'], fullName: '第一教学楼'),
+    BuildingAlias(campusName: '玉泉', aliases: ['教2'], fullName: '第二教学楼'),
+    BuildingAlias(campusName: '玉泉', aliases: ['教3'], fullName: '第三教学楼'),
+    BuildingAlias(campusName: '玉泉', aliases: ['教4'], fullName: '第四教学楼'),
+  ];
+
+  static String mapForCalendar(String? rawLocation) {
+    if (rawLocation == null) return '';
+    final raw = rawLocation.trim();
+    if (raw.isEmpty) return '';
+
+    final normalized = _normalizeDash(raw);
+    final parts = _splitHeadAndRoom(normalized);
+    if (parts == null) {
+      return _mapWithoutRoom(normalized);
+    }
+
+    final head = parts.$1;
+    final room = parts.$2;
+    if (head.isEmpty) return raw;
+
+    final mappedHead = _mapHeadToFullAddress(head);
+    if (mappedHead == null) return raw;
+    if (room.isEmpty) return mappedHead;
+    return '$mappedHead-$room';
+  }
+
+  static String _mapWithoutRoom(String raw) {
+    final mappedHead = _mapHeadToFullAddress(raw);
+    return mappedHead ?? raw;
+  }
+
+  static String? _mapHeadToFullAddress(String head) {
+    final campus = _matchCampus(head);
+    if (campus == null) return null;
+
+    final buildingRaw = _stripCampusAlias(head, campus).trim();
+    if (buildingRaw.isEmpty) {
+      return '浙江大学${campus.campusName}校区';
+    }
+
+    final buildingName = _mapBuildingName(campus.campusName, buildingRaw);
+    return '浙江大学${campus.campusName}校区$buildingName';
+  }
+
+  static CampusAlias? _matchCampus(String raw) {
+    for (final campus in _campusAliases) {
+      for (final alias in campus.aliases) {
+        if (raw.contains(alias)) return campus;
+      }
+    }
+    return null;
+  }
+
+  static String _stripCampusAlias(String raw, CampusAlias campus) {
+    var result = raw;
+    for (final alias in campus.aliases) {
+      result = result.replaceFirst(alias, '');
+    }
+    return result;
+  }
+
+  static String _mapBuildingName(String campusName, String buildingRaw) {
+    // 映射表
+    for (final item in _buildingAliases) {
+      if (item.campusName != null && item.campusName != campusName) continue;
+      if (item.aliases.contains(buildingRaw)) return item.fullName;
+    }
+
+    // 未命中，保留原始文本
+    return buildingRaw;
+  }
+
+  static (String, String)? _splitHeadAndRoom(String raw) {
+    final dashIndex = raw.indexOf('-');
+    if (dashIndex == -1) return null;
+    final head = raw.substring(0, dashIndex).trim();
+    final room = raw.substring(dashIndex + 1).trim();
+    return (head, room);
+  }
+
+  static String _normalizeDash(String raw) {
+    return raw
+        .replaceAll('－', '-')
+        .replaceAll('—', '-')
+        .replaceAll('–', '-')
+        .replaceAll('−', '-');
+  }
+}


### PR DESCRIPTION
zdbk中的上课地点是缩写格式（如 `紫金港西1-101`），直接写入 iOS 日历时无法被地图正确识别，对于使用“出发时间提醒”的用户来说，体验不好。

新增 `CalendarLocationMapper`，将缩写地址映射为 `原始缩写, 完整地址` 格式，保留可读性的同时让地图能正确解析。本人一直都在zjg，所以只配置了zjg的映射，其他校区需要其他开发者帮忙完善。 #106 #160 

**截图：**

<img width="534" height="1015" alt="803abff1db633bfdbad6a0f70648ee7a" src="https://github.com/user-attachments/assets/14d47d4b-c41c-4878-96f9-c00eecefcbc8" />

<img width="179" height="182" alt="image" src="https://github.com/user-attachments/assets/8d80246d-a8d7-4edc-bd4e-67b0de07d8da" />