### PR TITLE
feat: 支持保存多个账号并在设置页一键切换

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -888,3 +888,7 @@ DerivedData/
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
+
+# Claude AI
+.claude/
+CLAUDE.md

--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:get/get.dart';
 import 'package:hive/hive.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -58,6 +60,36 @@ class DatabaseHelper {
       await secureStorage.write(
           key: e.key, value: e.value, iOptions: secureStorageIOSOptions);
     });
+    // 多账号迁移：把既有单账号播种进账号列表，并把后台推送状态键复制到
+    // 账号命名空间。最后写 accountList 作为提交点，中途崩溃则下次整体重跑。
+    var accountListRaw = await secureStorage.read(
+        key: kAccountList, iOptions: secureStorageIOSOptions);
+    if (accountListRaw == null) {
+      var legacyUsername = await secureStorage.read(
+          key: kUsername, iOptions: secureStorageIOSOptions);
+      var legacyPassword = await secureStorage.read(
+          key: kPassword, iOptions: secureStorageIOSOptions);
+      if (legacyUsername != null &&
+          legacyUsername.isNotEmpty &&
+          legacyPassword != null) {
+        for (var key in backgroundStateKeys) {
+          var value = await secureStorage.read(
+              key: key, iOptions: secureStorageIOSOptions);
+          if (value != null) {
+            await secureStorage.write(
+                key: '${key}_$legacyUsername',
+                value: value,
+                iOptions: secureStorageIOSOptions);
+          }
+        }
+        await secureStorage.write(
+            key: kAccountList,
+            value: jsonEncode([
+              {'username': legacyUsername, 'password': legacyPassword}
+            ]),
+            iOptions: secureStorageIOSOptions);
+      }
+    }
   }
 
   // Options
@@ -251,6 +283,15 @@ class DatabaseHelper {
   final String dbScholar = 'dbUser';
   final String kUsername = 'username';
   final String kPassword = 'password';
+  final String kAccountList = 'accountList';
+
+  /// 后台推送状态键（仅由 background_app_refresh 读写），迁移后按账号命名空间隔离
+  static const List<String> backgroundStateKeys = [
+    'gpa',
+    'gradedCourseCount',
+    'pushOnGradeChangeFuse',
+    'notifiedDdlIds'
+  ];
 
   Future<Scholar> getScholar() async {
     var scholar = scholarBox.get('user', defaultValue: Scholar());
@@ -289,6 +330,104 @@ class DatabaseHelper {
       scholarBox.delete('user'),
       secureStorage.delete(key: kUsername, iOptions: secureStorageIOSOptions),
       secureStorage.delete(key: kPassword, iOptions: secureStorageIOSOptions)
+    ]);
+  }
+
+  // 多账号：账号列表存 secure storage，MRU 排序，首元素恒为当前账号；
+  // 非活跃账号的数据归档在各 box 的 <活动键>_<username> 键下
+
+  Future<List<Map<String, String>>> getAccountList() async {
+    var raw = await secureStorage.read(
+        key: kAccountList, iOptions: secureStorageIOSOptions);
+    if (raw == null) return <Map<String, String>>[];
+    try {
+      return (jsonDecode(raw) as List)
+          .map((e) => Map<String, String>.from(e as Map))
+          .toList();
+    } catch (_) {
+      return <Map<String, String>>[];
+    }
+  }
+
+  Future<void> setAccountList(List<Map<String, String>> accounts) async {
+    await secureStorage.write(
+        key: kAccountList,
+        value: jsonEncode(accounts),
+        iOptions: secureStorageIOSOptions);
+    // 首元素为当前账号，镜像到 legacy 键位，后台刷新与 e-card 组件按原键读取；
+    // 空表不动镜像键，由登出流程自行清理
+    if (accounts.isNotEmpty) {
+      await Future.wait([
+        secureStorage.write(
+            key: kUsername,
+            value: accounts.first['username'],
+            iOptions: secureStorageIOSOptions),
+        secureStorage.write(
+            key: kPassword,
+            value: accounts.first['password'],
+            iOptions: secureStorageIOSOptions),
+      ]);
+    }
+  }
+
+  /// 把活动槽位数据归档到 <key>_<username>，供切换账号时保存切出账号的档案
+  Future<void> archiveActiveProfile(
+      String username,
+      Scholar scholar,
+      List<Task> taskList,
+      DateTime taskListUpdateTime,
+      List<Period> flowList,
+      DateTime flowListUpdateTime) async {
+    await Future.wait([
+      scholarBox.put('user_$username', scholar),
+      taskBox.put('${kTaskList}_$username', taskList),
+      taskBox.put('${kTaskListUpdateTime}_$username', taskListUpdateTime),
+      flowBox.put('${kFlowList}_$username', flowList),
+      flowBox.put('${kFlowListUpdateTime}_$username', flowListUpdateTime),
+      customGpaBox.put('selectList_$username', getCustomGpa()),
+      customGpaBox.put('weightedGpa_$username', getWeightedGpa()),
+    ]);
+  }
+
+  ArchivedProfile readArchivedProfile(String username) {
+    var weightedRaw = customGpaBox.get('weightedGpa_$username') as Map?;
+    return ArchivedProfile(
+      scholar: scholarBox.get('user_$username') as Scholar?,
+      taskList:
+          List<Task>.from(taskBox.get('${kTaskList}_$username') ?? <Task>[]),
+      taskListUpdateTime: taskBox.get('${kTaskListUpdateTime}_$username') ??
+          DateTime.fromMicrosecondsSinceEpoch(0),
+      flowList: List<Period>.from(
+          flowBox.get('${kFlowList}_$username') ?? <Period>[]),
+      flowListUpdateTime: flowBox.get('${kFlowListUpdateTime}_$username') ??
+          DateTime.fromMicrosecondsSinceEpoch(0),
+      customGpa: Map<String, bool>.from(
+          customGpaBox.get('selectList_$username') ?? {}),
+      weightedGpa: weightedRaw == null
+          ? <String, double>{}
+          : Map<String, double>.from(weightedRaw.map((key, value) =>
+              MapEntry(key.toString(), (value as num).toDouble()))),
+    );
+  }
+
+  Future<void> deleteArchivedProfile(String username) async {
+    await Future.wait([
+      scholarBox.delete('user_$username'),
+      taskBox.delete('${kTaskList}_$username'),
+      taskBox.delete('${kTaskListUpdateTime}_$username'),
+      flowBox.delete('${kFlowList}_$username'),
+      flowBox.delete('${kFlowListUpdateTime}_$username'),
+      customGpaBox.delete('selectList_$username'),
+      customGpaBox.delete('weightedGpa_$username'),
+    ]);
+  }
+
+  /// 删除某账号的后台推送状态键（成绩基线、首推熔断、已提醒 DDL 集合）
+  Future<void> deleteBackgroundStateFor(String username) async {
+    await Future.wait([
+      for (var key in backgroundStateKeys)
+        secureStorage.delete(
+            key: '${key}_$username', iOptions: secureStorageIOSOptions)
     ]);
   }
 
@@ -350,4 +489,25 @@ class DatabaseHelper {
   Future<void> setWeightedGpa(Map<String, double> weightedMap) async {
     await customGpaBox.put('weightedGpa', weightedMap);
   }
+}
+
+/// 一个非活跃账号的归档档案快照。scholar 为空表示该账号从未归档过（新添账号）
+class ArchivedProfile {
+  final Scholar? scholar;
+  final List<Task> taskList;
+  final DateTime taskListUpdateTime;
+  final List<Period> flowList;
+  final DateTime flowListUpdateTime;
+  final Map<String, bool> customGpa;
+  final Map<String, double> weightedGpa;
+
+  ArchivedProfile({
+    required this.scholar,
+    required this.taskList,
+    required this.taskListUpdateTime,
+    required this.flowList,
+    required this.flowListUpdateTime,
+    required this.customGpa,
+    required this.weightedGpa,
+  });
 }

--- a/lib/model/calendar_to_system.dart
+++ b/lib/model/calendar_to_system.dart
@@ -43,7 +43,8 @@ class CalendarToSystemManager {
   // Celechron课表日历的ID
   String? _celechronCalendarId;
 
-  final Scholar scholar;
+  // 持有 Rx 本体而非 Scholar 对象，账号切换后自动指向新账号
+  final Rx<Scholar> scholar;
 
   // 日历同步状态
   final RxBool _calendarSyncEnabled = false.obs;
@@ -171,10 +172,10 @@ class CalendarToSystemManager {
 
       if (syncAllSemesters) {
         // 同步所有学期
-        allPeriods = scholar.periods;
+        allPeriods = scholar.value.periods;
       } else {
         // 同步指定学期或当前学期
-        var targetSemester = semester ?? scholar.thisSemester;
+        var targetSemester = semester ?? scholar.value.thisSemester;
         allPeriods = targetSemester.periods;
       }
 
@@ -318,12 +319,13 @@ class CalendarToSystemManager {
 
   /// 获取可用学期列表（供UI使用）
   List<String> getAvailableSemesters() {
-    return scholar.semesters.map((semester) => semester.name).toList();
+    return scholar.value.semesters.map((semester) => semester.name).toList();
   }
 
   /// 根据学期名称获取学期对象
   Semester? getSemesterByName(String semesterName) {
-    return scholar.semesters.firstWhereOrNull((s) => s.name == semesterName);
+    return scholar.value.semesters
+        .firstWhereOrNull((s) => s.name == semesterName);
   }
 
   /// 删除整个Celechron日历
@@ -395,6 +397,18 @@ class CalendarToSystemManager {
         ),
         barrierDismissible: true,
       );
+    }
+  }
+
+  /// 账号切换后静默重建日历内容：未开启同步或无权限时不做任何事，不弹窗
+  Future<void> resyncSilently() async {
+    if (!_calendarSyncEnabled.value) return;
+    try {
+      if (!await checkPermissions()) return;
+      await clearSyncedEvents();
+      await syncScholarToSystemCalendar();
+    } catch (e) {
+      // 静默失败，用户可在设置页手动重新同步
     }
   }
 
@@ -622,7 +636,7 @@ class CalendarToSystemManager {
       }
 
       // 检查是否已登录
-      if (!scholar.isLogan) {
+      if (!scholar.value.isLogan) {
         _showAlert(context, '提示', '请先登录后再开启日历同步功能');
         return;
       }

--- a/lib/page/option/account_manage_page.dart
+++ b/lib/page/option/account_manage_page.dart
@@ -25,7 +25,7 @@ class AccountManagePage extends StatelessWidget {
             const CelechronSliverTextHeader(subtitle: '账号管理'),
             SliverToBoxAdapter(
               child: Obx(() {
-                var accounts = _optionController.accounts;
+                var accounts = _optionController.accountsSortedById;
                 var currentUsername = _optionController.scholar.value.username;
                 var isLogan = _optionController.scholar.value.isLogan;
                 return Column(children: [
@@ -153,7 +153,7 @@ class AccountManagePage extends StatelessWidget {
           return CupertinoAlertDialog(
             title: const Text('退出当前账号'),
             content: Text(hasOthers
-                ? '将删除该账号在本机的全部数据（包括任务与规划），并切换到下一个账号。'
+                ? '将删除该账号在本机的全部数据（包括任务与规划），并切换到最近使用的另一个账号。'
                 : '将删除该账号在本机的全部数据（包括任务与规划）。'),
             actions: [
               CupertinoDialogAction(

--- a/lib/page/option/account_manage_page.dart
+++ b/lib/page/option/account_manage_page.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/cupertino.dart';
+import 'package:get/get.dart';
+
+import 'package:celechron/design/persistent_headers.dart';
+import 'login_page.dart';
+import 'option_controller.dart';
+
+class AccountManagePage extends StatelessWidget {
+  final _optionController = Get.find<OptionController>(tag: 'optionController');
+
+  AccountManagePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var headerFooterTextStyle = TextStyle(
+        color: CupertinoDynamicColor.resolve(
+            CupertinoColors.secondaryLabel, context),
+        fontSize: 14);
+
+    return CupertinoPageScaffold(
+      backgroundColor: CupertinoColors.systemGroupedBackground,
+      child: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            const CelechronSliverTextHeader(subtitle: '账号管理'),
+            SliverToBoxAdapter(
+              child: Obx(() {
+                var accounts = _optionController.accounts;
+                var currentUsername = _optionController.scholar.value.username;
+                var isLogan = _optionController.scholar.value.isLogan;
+                return Column(children: [
+                  if (accounts.isNotEmpty)
+                    CupertinoListSection.insetGrouped(
+                      additionalDividerMargin: 2,
+                      header: Container(
+                          padding: const EdgeInsets.only(left: 16),
+                          child: Text('已存账号', style: headerFooterTextStyle)),
+                      footer: accounts.length > 1
+                          ? Container(
+                              padding: const EdgeInsets.only(left: 16),
+                              child: Text('点击账号即可切换，左滑可删除非当前账号。',
+                                  style: headerFooterTextStyle))
+                          : null,
+                      children: [
+                        for (var account in accounts)
+                          _buildAccountRow(context, account,
+                              account['username'] == currentUsername),
+                      ],
+                    ),
+                  CupertinoListSection.insetGrouped(
+                    additionalDividerMargin: 2,
+                    children: [
+                      CupertinoListTile(
+                        title: const Text('添加新账号',
+                            style:
+                                TextStyle(color: CupertinoColors.activeBlue)),
+                        onTap: () {
+                          showCupertinoModalPopup(
+                              context: context,
+                              builder: (BuildContext context) {
+                                return LoginForm();
+                              });
+                        },
+                      ),
+                      if (isLogan)
+                        CupertinoListTile(
+                          title: const Text('退出当前账号',
+                              style: TextStyle(
+                                  color: CupertinoColors.destructiveRed)),
+                          onTap: () => _confirmSignOut(context),
+                        ),
+                    ],
+                  ),
+                ]);
+              }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAccountRow(
+      BuildContext context, Map<String, String> account, bool isCurrent) {
+    var username = account['username'] ?? '';
+    var tile = CupertinoListTile(
+      title: Text(username),
+      trailing: isCurrent
+          ? const Icon(CupertinoIcons.check_mark,
+              color: CupertinoColors.activeBlue, size: 20)
+          : null,
+      onTap: isCurrent
+          ? null
+          : () {
+              if (_optionController.accountBusy.value) return;
+              _optionController.switchAccount(username);
+            },
+    );
+    if (isCurrent) return tile;
+
+    return Dismissible(
+      key: Key('account_$username'),
+      direction: DismissDirection.endToStart,
+      movementDuration: const Duration(milliseconds: 300),
+      resizeDuration: const Duration(milliseconds: 300),
+      dismissThresholds: const {DismissDirection.endToStart: 0.25},
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 16),
+        color: CupertinoColors.systemRed,
+        child: const Icon(
+          CupertinoIcons.delete,
+          color: CupertinoColors.white,
+          size: 20,
+        ),
+      ),
+      confirmDismiss: (direction) async {
+        if (_optionController.accountBusy.value) return false;
+        return await showCupertinoDialog<bool>(
+              context: context,
+              builder: (BuildContext dialogContext) {
+                return CupertinoAlertDialog(
+                  title: const Text('删除账号'),
+                  content: Text('将从本机删除账号 $username 及其缓存数据（包括任务与规划）。'),
+                  actions: [
+                    CupertinoDialogAction(
+                      child: const Text('取消'),
+                      onPressed: () => Navigator.of(dialogContext).pop(false),
+                    ),
+                    CupertinoDialogAction(
+                      isDestructiveAction: true,
+                      child: const Text('删除'),
+                      onPressed: () => Navigator.of(dialogContext).pop(true),
+                    ),
+                  ],
+                );
+              },
+            ) ??
+            false;
+      },
+      onDismissed: (direction) {
+        _optionController.deleteAccount(username);
+      },
+      child: tile,
+    );
+  }
+
+  void _confirmSignOut(BuildContext context) {
+    var hasOthers = _optionController.accounts.length > 1;
+    showCupertinoDialog(
+        context: context,
+        builder: (BuildContext dialogContext) {
+          return CupertinoAlertDialog(
+            title: const Text('退出当前账号'),
+            content: Text(hasOthers
+                ? '将删除该账号在本机的全部数据（包括任务与规划），并切换到下一个账号。'
+                : '将删除该账号在本机的全部数据（包括任务与规划）。'),
+            actions: [
+              CupertinoDialogAction(
+                child: const Text('取消'),
+                onPressed: () => Navigator.of(dialogContext).pop(),
+              ),
+              CupertinoDialogAction(
+                isDestructiveAction: true,
+                child: const Text('退出'),
+                onPressed: () async {
+                  Navigator.of(dialogContext).pop();
+                  await _optionController.signOutCurrent();
+                },
+              ),
+            ],
+          );
+        });
+  }
+}

--- a/lib/page/option/login_page.dart
+++ b/lib/page/option/login_page.dart
@@ -1,9 +1,6 @@
-import 'package:celechron/utils/platform_features.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:get/get.dart';
-import 'package:celechron/model/scholar.dart';
 
-import '../../worker/ecard_widget_messenger.dart';
 import 'option_controller.dart';
 
 class LoginForm extends StatelessWidget {
@@ -90,48 +87,41 @@ class LoginForm extends StatelessWidget {
                     const SizedBox(height: 16),
                     Obx(() => CupertinoButton(
                         onPressed: () async {
+                          if (buttonPressed.value) return;
                           buttonPressed.value = true;
-                          var scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
-                          scholar.update((val) {
-                            val!.username = usernameController.value.text;
-                            val.password = passwordController.value.text;
-                            val.login().then((value) async {
-                              if (value.every((e) => e == null)) {
-                                await val.refresh(
-                                    onPartialUpdate: scholar.refresh);
-                                scholar.refresh();
-                                buttonPressed.value = false;
-                                _optionController.pushOnGradeChange =
-                                    PlatformFeatures.hasBackgroundRefresh;
-                                if (context.mounted) {
-                                  Navigator.of(context).pop();
-                                }
-                              } else {
-                                buttonPressed.value = false;
-                                if (!context.mounted) return;
-                                showCupertinoDialog(
-                                    context: context,
-                                    builder: (context) {
-                                      return CupertinoAlertDialog(
-                                        title: const Text('登录失败'),
-                                        content: Text(value
-                                            .where((e) => e != null)
-                                            .fold('', (p, v) => '$p\n$v')
-                                            .trim()),
-                                        actions: [
-                                          CupertinoDialogAction(
-                                            child: const Text('确定'),
-                                            onPressed: () async {
-                                              Navigator.of(context).pop();
-                                            },
-                                          )
-                                        ],
-                                      );
-                                    });
-                              }
-                              ECardWidgetMessenger.update();
-                            });
-                          });
+                          // 试登录、归档与账号列表维护都在控制器里完成；
+                          // 登录失败不会碰当前账号的任何数据
+                          var errors =
+                              await _optionController.addOrUpdateAccount(
+                                  usernameController.value.text,
+                                  passwordController.value.text);
+                          buttonPressed.value = false;
+                          if (errors.every((e) => e == null)) {
+                            if (context.mounted) {
+                              Navigator.of(context).pop();
+                            }
+                          } else {
+                            if (!context.mounted) return;
+                            showCupertinoDialog(
+                                context: context,
+                                builder: (context) {
+                                  return CupertinoAlertDialog(
+                                    title: const Text('登录失败'),
+                                    content: Text(errors
+                                        .where((e) => e != null)
+                                        .fold('', (p, v) => '$p\n$v')
+                                        .trim()),
+                                    actions: [
+                                      CupertinoDialogAction(
+                                        child: const Text('确定'),
+                                        onPressed: () async {
+                                          Navigator.of(context).pop();
+                                        },
+                                      )
+                                    ],
+                                  );
+                                });
+                          }
                         },
                         color: buttonPressed.value
                             ? CupertinoColors.inactiveGray

--- a/lib/page/option/option_controller.dart
+++ b/lib/page/option/option_controller.dart
@@ -244,6 +244,19 @@ class OptionController extends GetxController {
   // <键>_<username> 下。切换的核心是一个不含 await 的同步交换块，
   // 保证 TaskController/FlowController 的秒级 tick 观察不到混合态。
 
+  /// 账号管理页展示用：按学号从小到大排序，不随切换变化。
+  /// 底层 accounts 仍为 MRU 序——首元素镜像凭据、退出后回退都依赖它
+  List<Map<String, String>> get accountsSortedById {
+    var sorted = accounts.toList();
+    sorted.sort((a, b) {
+      var ua = a['username'] ?? '';
+      var ub = b['username'] ?? '';
+      // 学号均为数字串，先比长度再比字典序即数值序
+      return ua.length != ub.length ? ua.length - ub.length : ua.compareTo(ub);
+    });
+    return sorted;
+  }
+
   /// 切换到已存账号。瞬间换上其缓存档案，随后复刻启动逻辑后台登录刷新
   Future<void> switchAccount(String username) async {
     if (accountBusy.value) return;

--- a/lib/page/option/option_controller.dart
+++ b/lib/page/option/option_controller.dart
@@ -8,12 +8,16 @@ import 'package:workmanager/workmanager.dart';
 
 import 'package:celechron/model/scholar.dart';
 import 'package:celechron/model/option.dart';
+import 'package:celechron/model/task.dart';
+import 'package:celechron/model/period.dart';
 import 'package:celechron/services/diagnostic_log_service.dart';
 import 'package:celechron/database/database_helper.dart';
+import 'package:celechron/page/scholar/scholar_controller.dart';
 import 'package:celechron/worker/ecard_widget_messenger.dart';
 import 'package:celechron/worker/fuse.dart';
 import 'package:celechron/worker/background_app_refresh.dart';
 import 'package:celechron/utils/platform_features.dart';
+import 'package:celechron/utils/global.dart';
 import 'package:celechron/model/calendar_to_system.dart';
 import 'package:celechron/model/calendar_to_ical.dart';
 
@@ -28,7 +32,17 @@ class OptionController extends GetxController {
   final scholar = Get.find<Rx<Scholar>>(tag: 'scholar');
   final _fuse = Get.find<Rx<Fuse>>(tag: 'fuse');
   final _db = Get.find<DatabaseHelper>(tag: 'db');
+  final _taskList = Get.find<RxList<Task>>(tag: 'taskList');
+  final _taskListLastUpdate = Get.find<Rx<DateTime>>(tag: 'taskListLastUpdate');
+  final _flowList = Get.find<RxList<Period>>(tag: 'flowList');
+  final _flowListLastUpdate = Get.find<Rx<DateTime>>(tag: 'flowListLastUpdate');
   late final RxInt allowTimeLength = _option.allowTime.length.obs;
+
+  /// 已存账号，MRU 排序，首元素恒为当前账号；密码仅在切换/登录时使用
+  final accounts = <Map<String, String>>[].obs;
+
+  /// 账号切换/添加/退出进行中，串行化防并发
+  final accountBusy = false.obs;
 
   // 日历管理器
   late final CalendarToSystemManager _calendarManager;
@@ -36,7 +50,8 @@ class OptionController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    _calendarManager = CalendarToSystemManager(scholar.value);
+    _calendarManager = CalendarToSystemManager(scholar);
+    _db.getAccountList().then(accounts.assignAll);
 
     if (PlatformFeatures.hasBackgroundRefresh) {
       if (_option.pushOnGradeChange.value || _option.pushOnDdlReminder.value) {
@@ -224,11 +239,304 @@ class OptionController extends GetxController {
 
   bool get hasNewVersion => _fuse.value.hasNewVersion;
 
-  Future<void> logout() async {
-    await scholar.value.logout();
+  // —— 多账号 ——
+  // 活动槽位 + 归档：当前账号数据在各 box 的原键位，非活跃账号归档在
+  // <键>_<username> 下。切换的核心是一个不含 await 的同步交换块，
+  // 保证 TaskController/FlowController 的秒级 tick 观察不到混合态。
+
+  /// 切换到已存账号。瞬间换上其缓存档案，随后复刻启动逻辑后台登录刷新
+  Future<void> switchAccount(String username) async {
+    if (accountBusy.value) return;
+    accountBusy.value = true;
+    try {
+      await _switchAccountLocked(username);
+    } finally {
+      accountBusy.value = false;
+    }
+  }
+
+  Future<void> _switchAccountLocked(String username) async {
+    var target = accounts.firstWhereOrNull((e) => e['username'] == username);
+    if (target == null || username == scholar.value.username) return;
+
+    var writes = <Future>[];
+    var next = _activateProfile(target, writes);
+    accounts.remove(target);
+    accounts.insert(0, target);
+
+    // 先等归档与活动槽位落盘，再写 accountList 作为提交点；
+    // 目标账号的归档键等提交完成后再删，中途被杀不丢档案
+    await Future.wait(writes);
+    await _db.setAccountList(accounts.toList());
+    await _db.deleteArchivedProfile(username);
+    await _db.removeAllCachedWebPage();
+    if (Get.isRegistered<ScholarController>()) {
+      Get.find<ScholarController>().resetSemesterIndex();
+    }
+
+    _refreshInBackground(next);
+  }
+
+  /// 添加新账号或更新已存账号的密码。返回登录错误列表（全 null 为成功）。
+  /// 试登录用不挂 db 的临时 Scholar，失败不碰当前账号任何状态
+  Future<List<String?>> addOrUpdateAccount(
+      String username, String password) async {
+    if (username.isEmpty || password.isEmpty) return ['请输入学号与密码'];
+    if (accountBusy.value) return ['正在处理其他账号操作，请稍后再试'];
+    accountBusy.value = true;
+    try {
+      var probe = Scholar();
+      probe.username = username;
+      probe.password = password;
+      var errors = await probe.login();
+      if (errors.any((e) => e != null)) return errors;
+
+      var entry = {'username': username, 'password': password};
+      var index = accounts.indexWhere((e) => e['username'] == username);
+
+      if (username == scholar.value.username) {
+        // 当前账号改密码：换上新凭据。旧 spider 缓存着旧密码，而 refresh
+        // 只在无会话时才内部重登，须显式 login 重建会话后再刷新
+        scholar.value.password = password;
+        if (index >= 0) {
+          accounts[index] = entry;
+        } else {
+          accounts.insert(0, entry);
+        }
+        await _db.setScholar(scholar.value);
+        await _db.setAccountList(accounts.toList());
+        var s = scholar.value;
+        unawaited(() async {
+          try {
+            var loginErrors = await s.login();
+            if (loginErrors.every((e) => e == null)) {
+              await _refreshAccountScholar(s);
+            }
+          } on Object catch (error, stackTrace) {
+            DiagnosticLogService.instance.record(
+              level: CelechronLogLevel.warning,
+              module: 'refresh',
+              operation: 'passwordUpdateRelogin',
+              message: '更新密码后的重新登录异常结束',
+              error: error,
+              stackTrace: stackTrace,
+            );
+          } finally {
+            unawaited(ECardWidgetMessenger.update());
+          }
+        }());
+        return errors;
+      }
+
+      if (index >= 0) {
+        // 已存账号：原位更新密码（位次交给切换流程调整），随后切换过去
+        accounts[index] = entry;
+        await _db.setAccountList(accounts.toList());
+        await _switchAccountLocked(username);
+        return errors;
+      }
+
+      // 新账号：归档当前账号（若有），probe 转正为活动 Scholar
+      var writes = <Future>[];
+      _adoptNewAccount(probe, writes);
+      accounts.insert(0, entry);
+      await Future.wait(writes);
+      await _db.setAccountList(accounts.toList());
+      await _db.removeAllCachedWebPage();
+      if (Get.isRegistered<ScholarController>()) {
+        Get.find<ScholarController>().resetSemesterIndex();
+      }
+      pushOnGradeChange = PlatformFeatures.hasBackgroundRefresh;
+      // probe 已持有登录会话，refresh 不会重复登录
+      _refreshInBackground(probe);
+      return errors;
+    } finally {
+      accountBusy.value = false;
+    }
+  }
+
+  /// 退出当前账号并删除其本机全部数据（含任务与规划）。
+  /// 还有其他账号时自动切到最近使用的一个，否则回到未登录空态
+  Future<void> signOutCurrent() async {
+    if (accountBusy.value) return;
+    accountBusy.value = true;
+    try {
+      var old = scholar.value;
+      var oldUsername = old.username;
+      accounts.removeWhere((e) => e['username'] == oldUsername);
+
+      if (accounts.isNotEmpty) {
+        var target = accounts.first;
+        var writes = <Future>[];
+        var next = _activateProfile(target, writes, archiveCurrent: false);
+        await Future.wait(writes);
+        await _db.setAccountList(accounts.toList());
+        await _db.deleteArchivedProfile(target['username']!);
+        if (oldUsername != null && oldUsername.isNotEmpty) {
+          await _db.deleteArchivedProfile(oldUsername); // 常态不存在，防残档
+          await _db.deleteBackgroundStateFor(oldUsername);
+        }
+        await _db.removeAllCachedWebPage();
+        if (Get.isRegistered<ScholarController>()) {
+          Get.find<ScholarController>().resetSemesterIndex();
+        }
+        _refreshInBackground(next);
+        return;
+      }
+
+      // 无剩余账号：回到未登录空态。old.db 已置空，在途刷新不可能把
+      // 旧账号数据写回槽位；db 侧清理在此直接做，不再调用 old.logout()
+      old.db = null;
+      var epoch = DateTime.fromMicrosecondsSinceEpoch(0);
+      _flowListLastUpdate.value = epoch;
+      _flowList.clear();
+      _taskListLastUpdate.value = epoch;
+      _taskList.clear();
+      scholar.value = Scholar()..db = _db;
+      var clearWrites = <Future>[
+        _db.setCustomGpa({}),
+        _db.setWeightedGpa({}),
+        _db.setTaskList([]),
+        _db.setTaskListUpdateTime(epoch),
+        _db.setFlowList([]),
+        _db.setFlowListUpdateTime(epoch),
+      ];
+      await Future.wait(clearWrites);
+      // 写空表保留 accountList 键，后台刷新维持「已迁移」门控
+      await _db.setAccountList([]);
+      await _db.removeScholar();
+      if (oldUsername != null && oldUsername.isNotEmpty) {
+        await _db.deleteArchivedProfile(oldUsername);
+        await _db.deleteBackgroundStateFor(oldUsername);
+      }
+      await _db.removeAllCachedWebPage();
+      scholar.refresh();
+      pushOnGradeChange = false;
+      ECardWidgetMessenger.logout();
+    } finally {
+      accountBusy.value = false;
+    }
+  }
+
+  /// 删除一个非当前账号及其本机归档
+  Future<void> deleteAccount(String username) async {
+    if (accountBusy.value) return;
+    if (username == scholar.value.username) return; // 当前账号走退出流程
+    accountBusy.value = true;
+    try {
+      accounts.removeWhere((e) => e['username'] == username);
+      await _db.setAccountList(accounts.toList());
+      await _db.deleteArchivedProfile(username);
+      await _db.deleteBackgroundStateFor(username);
+      accounts.refresh();
+    } finally {
+      accountBusy.value = false;
+    }
+  }
+
+  /// 同步交换块：归档当前账号（可选）、把目标账号档案装入内存与活动槽位。
+  /// 全程无 await；产生的落盘 future 收集进 [writes] 由调用方统一等待
+  Scholar _activateProfile(Map<String, String> target, List<Future> writes,
+      {bool archiveCurrent = true}) {
+    var old = scholar.value;
+    // 切出账号在途刷新的落盘全部作废，防止旧账号数据写进新账号槽位
+    old.db = null;
+    if (archiveCurrent &&
+        old.isLogan &&
+        old.username != null &&
+        old.username!.isNotEmpty) {
+      writes.add(_db.archiveActiveProfile(
+          old.username!,
+          old,
+          List<Task>.from(_taskList),
+          _taskListLastUpdate.value,
+          List<Period>.from(_flowList),
+          _flowListLastUpdate.value));
+    }
+
+    var restored = _db.readArchivedProfile(target['username']!);
+    // 从未归档过的账号（如中途被杀）兜底为空数据的已登录状态，等异步刷新填充
+    var next = restored.scholar ?? (Scholar()..isLogan = true);
+    next.username = target['username'];
+    next.password = target['password'];
+    next.db = _db;
+
+    // scholar 最后赋值：ever(scholar) 触发的小组件推送拿到的是完整新态
+    _flowListLastUpdate.value = restored.flowListUpdateTime;
+    _flowList.assignAll(restored.flowList);
+    _taskListLastUpdate.value = restored.taskListUpdateTime;
+    _taskList.assignAll(restored.taskList);
+    scholar.value = next;
+
+    // 活动槽位持久化。Hive put 同步更新内存，磁盘刷写由 writes 兜底
+    writes.add(_db.setCustomGpa(restored.customGpa));
+    writes.add(_db.setWeightedGpa(restored.weightedGpa));
+    writes.add(_db.setTaskList(restored.taskList));
+    writes.add(_db.setTaskListUpdateTime(restored.taskListUpdateTime));
+    writes.add(_db.setFlowList(restored.flowList));
+    writes.add(_db.setFlowListUpdateTime(restored.flowListUpdateTime));
+    writes.add(_db.setScholar(next));
+    return next;
+  }
+
+  /// 同步交换块（添加新账号）：归档当前账号后 probe 转正。
+  /// 首登（此前未登录）不清任务——离线期建的任务归属首个账号
+  void _adoptNewAccount(Scholar probe, List<Future> writes) {
+    var old = scholar.value;
+    old.db = null;
+    if (old.isLogan && old.username != null && old.username!.isNotEmpty) {
+      writes.add(_db.archiveActiveProfile(
+          old.username!,
+          old,
+          List<Task>.from(_taskList),
+          _taskListLastUpdate.value,
+          List<Period>.from(_flowList),
+          _flowListLastUpdate.value));
+      var epoch = DateTime.fromMicrosecondsSinceEpoch(0);
+      _flowListLastUpdate.value = epoch;
+      _flowList.clear();
+      _taskListLastUpdate.value = epoch;
+      _taskList.clear();
+      writes.add(_db.setCustomGpa({}));
+      writes.add(_db.setWeightedGpa({}));
+      writes.add(_db.setTaskList([]));
+      writes.add(_db.setTaskListUpdateTime(epoch));
+      writes.add(_db.setFlowList([]));
+      writes.add(_db.setFlowListUpdateTime(epoch));
+    }
+    probe.db = _db;
+    scholar.value = probe;
+    writes.add(_db.setScholar(probe));
+  }
+
+  /// 复刻 main.dart 的启动逻辑：先展示缓存，后台完成刷新（会话重建由
+  /// Scholar.refresh 内部完成）。捕获局部 [s]：若刷新途中账号又被切走，
+  /// s.db 已被置空，落盘自动作废。校园卡走另一套 CAS 链路，等刷新收尾
+  /// 后再更新，避免两条认证链路互相干扰
+  void _refreshInBackground(Scholar s) {
     scholar.refresh();
-    pushOnGradeChange = false;
-    ECardWidgetMessenger.logout();
+    unawaited(_refreshAccountScholar(s)
+        .whenComplete(() => unawaited(ECardWidgetMessenger.update())));
+  }
+
+  Future<void> _refreshAccountScholar(Scholar s) async {
+    GlobalStatus.isFirstScreenReq = true;
+    try {
+      await s.refresh(onPartialUpdate: scholar.refresh);
+      await _calendarManager.resyncSilently();
+    } on Object catch (error, stackTrace) {
+      DiagnosticLogService.instance.record(
+        level: CelechronLogLevel.error,
+        module: 'refresh',
+        operation: 'accountRefresh',
+        message: '账号切换/添加后的自动刷新异常结束',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      GlobalStatus.isFirstScreenReq = false;
+      scholar.refresh();
+    }
   }
 
   /// calendar_to_ical.dart: 显示导出课程表对话框

--- a/lib/page/option/option_view.dart
+++ b/lib/page/option/option_view.dart
@@ -9,6 +9,7 @@ import 'package:celechron/model/option.dart';
 import 'package:celechron/design/cupertino_async_switch.dart';
 
 import 'allow_time_edit_page.dart';
+import 'account_manage_page.dart';
 import 'course_id_mapping_edit_page.dart';
 import 'credits_page.dart';
 import 'diagnostic_log_page.dart';
@@ -82,37 +83,17 @@ class OptionPage extends StatelessWidget {
                             title: Text(
                                 '已登录: ${_optionController.scholar.value.username}'),
                             trailing: BackChervonRow(
-                                child: Text('退出',
+                                child: Text('管理',
                                     style: TextStyle(
                                         color: CupertinoDynamicColor.resolve(
                                             CupertinoColors.secondaryLabel,
                                             context),
                                         fontSize: 16))),
                             onTap: () async {
-                              await showCupertinoDialog(
-                                  context: context,
-                                  builder: (BuildContext dialogContext) {
-                                    return CupertinoAlertDialog(
-                                      title: const Text('退出登录'),
-                                      content: const Text('确定要退出当前账号吗？'),
-                                      actions: [
-                                        CupertinoDialogAction(
-                                          child: const Text('取消'),
-                                          onPressed: () {
-                                            Navigator.of(dialogContext).pop();
-                                          },
-                                        ),
-                                        CupertinoDialogAction(
-                                          isDestructiveAction: true,
-                                          child: const Text('退出'),
-                                          onPressed: () async {
-                                            Navigator.of(dialogContext).pop();
-                                            await _optionController.logout();
-                                          },
-                                        ),
-                                      ],
-                                    );
-                                  });
+                              Navigator.of(context, rootNavigator: true).push(
+                                  CupertinoPageRoute(
+                                      builder: (context) =>
+                                          AccountManagePage()));
                             }),
                         CupertinoListTile(
                           title: const Text('重修绩点计算'),

--- a/lib/page/scholar/scholar_controller.dart
+++ b/lib/page/scholar/scholar_controller.dart
@@ -240,13 +240,17 @@ class ScholarController extends GetxController {
     }
   }
 
-  @override
-  void onReady() {
-    super.onReady();
-    // 在生命周期方法中正确初始化 semesterIndex
+  /// 按当前学期重置学期下标；进页初始化与账号切换后都走这里
+  void resetSemesterIndex() {
     final thisSemesterIndex =
         semesters.indexWhere((e) => e.name == _scholar.value.thisSemester.name);
     semesterIndex.value = thisSemesterIndex >= 0 ? thisSemesterIndex : 0;
+  }
+
+  @override
+  void onReady() {
+    super.onReady();
+    resetSemesterIndex();
 
     _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
       _updateDurations();

--- a/lib/worker/background_app_refresh.dart
+++ b/lib/worker/background_app_refresh.dart
@@ -95,20 +95,26 @@ Future<void> refreshScholar() async {
       key: 'username', iOptions: secureStorageIOSOptions);
   scholar.password = await secureStorage.read(
       key: 'password', iOptions: secureStorageIOSOptions);
-  var oldGpa =
-      await secureStorage.read(key: 'gpa', iOptions: secureStorageIOSOptions) ??
-          '0.0';
+  if (scholar.username == null) return;
+  // 多账号：迁移后（accountList 已写入）推送状态键按当前账号命名空间隔离，
+  // 各账号保有各自的成绩基线与已提醒集合；未迁移时沿用 legacy 键，行为不变
+  var accountListRaw = await secureStorage.read(
+      key: 'accountList', iOptions: secureStorageIOSOptions);
+  var ns = accountListRaw == null ? '' : '_${scholar.username}';
+  var oldGpa = await secureStorage.read(
+          key: 'gpa$ns', iOptions: secureStorageIOSOptions) ??
+      '0.0';
   var gradedCourseCount = await secureStorage.read(
-          key: 'gradedCourseCount', iOptions: secureStorageIOSOptions) ??
+          key: 'gradedCourseCount$ns', iOptions: secureStorageIOSOptions) ??
       '0';
   var pushOnGradeChangeFuse = await secureStorage.read(
-      key: 'pushOnGradeChangeFuse', iOptions: secureStorageIOSOptions);
+      key: 'pushOnGradeChangeFuse$ns', iOptions: secureStorageIOSOptions);
   var pushOnGradeChange = await secureStorage.read(
       key: 'pushOnGradeChange', iOptions: secureStorageIOSOptions);
   var pushOnDdlReminder = await secureStorage.read(
       key: 'pushOnDdlReminder', iOptions: secureStorageIOSOptions);
   var notifiedDdlIdsStr = await secureStorage.read(
-      key: 'notifiedDdlIds', iOptions: secureStorageIOSOptions);
+      key: 'notifiedDdlIds$ns', iOptions: secureStorageIOSOptions);
 
   try {
     var backgroundYielded = false;
@@ -135,7 +141,7 @@ Future<void> refreshScholar() async {
             '若有新出分的课程，Celechron 将会通知您。若不需要此功能，可在 Celechron 的设置页面中关闭。',
             gradeNotificationDetails);
         await secureStorage.write(
-            key: 'pushOnGradeChangeFuse',
+            key: 'pushOnGradeChangeFuse$ns',
             value: '1',
             iOptions: secureStorageIOSOptions);
       } else if (scholar.gpa[0] != double.tryParse(oldGpa) ||
@@ -144,11 +150,11 @@ Future<void> refreshScholar() async {
             '有新出分的课程，可在 Celechron 的学业页面中刷新查看。', gradeNotificationDetails);
       }
       await secureStorage.write(
-          key: 'gpa',
+          key: 'gpa$ns',
           value: scholar.gpa[0].toString(),
           iOptions: secureStorageIOSOptions);
       await secureStorage.write(
-          key: 'gradedCourseCount',
+          key: 'gradedCourseCount$ns',
           value: scholar.gradedCourseCount.toString(),
           iOptions: secureStorageIOSOptions);
     }
@@ -196,7 +202,7 @@ Future<void> refreshScholar() async {
       });
 
       await secureStorage.write(
-          key: 'notifiedDdlIds',
+          key: 'notifiedDdlIds$ns',
           value: jsonEncode(notifiedDdlIds.toList()),
           iOptions: secureStorageIOSOptions);
     }


### PR DESCRIPTION
## 概述

设置页新增“账号管理”:可保存多个统一身份认证账号,点击即切换。每个账号在本机
保留一份完全隔离的档案(学业数据、自建任务、Flow 规划、自定义绩点),切换瞬间
展示该账号上次的缓存数据,随后复用启动逻辑在后台异步刷新,来回切换均为秒切。

## 交互

- 设置页“已登录: 学号”行尾由“退出”改为“管理”,点击进入账号管理页
- 账号列表按学号从小到大排序、不随切换变化,当前账号带 ✓,点击其他账号即切换
- 左滑删除非当前账号(带确认框)
- “添加新账号”复用原登录弹窗,试登录失败不影响当前账号任何数据
- “退出当前账号”删除该账号在本机的全部数据(含任务与规划,确认框有明确警告);
  还有其他账号时自动切到最近使用的一个,否则回到未登录状态

## 实现要点

- **活动槽位 + 归档**:当前账号数据仍在原有 Hive 键位,TaskController /
  FlowController / 启动流程零改动;非活跃账号归档在同 box 的 `<键>_<学号>` 键下。
  不新增 typeId、不改 adapter、不碰平台原生文件
- **凭据镜像**:账号列表存 secure storage 新键 `accountList`(MRU 序,首元素恒为
  当前账号,供退出后回退),旧的 `username` / `password` 键始终镜像当前账号,
  后台刷新与 e-card 小组件的凭据读取零改动;界面展示时另按学号排序
- **切换竞态防护**:切换核心是不含 await 的同步交换块,定时器 tick 观察不到混合态;
  切出账号的 db 引用置空,在途刷新的落盘自动作废,不会串账
- **后台推送状态隔离**:成绩基线、已提醒 DDL 集合等状态键按账号命名空间
  (`gpa_<学号>` 等),切换后不会误报“成绩变动”;以 `accountList` 是否存在做门控,
  未迁移时后台行为与旧版完全一致
- **迁移幂等**:升级后首次启动把既有账号播种进账号列表,先复制后台状态键、
  最后写 accountList 作为提交点,中途被杀下次整体重跑
- 日历同步管理器改持 `Rx<Scholar>`,切换后静默重建系统日历;学业页学期下标自动重置

注：分支已 rebase 到最新 main,并按新契约做了适配:

- 切换/添加账号后的自动刷新只调 `Scholar.refresh()`,会话重建由其内部完成,
  与新版 main.dart 启动逻辑一致;异常记入诊断日志
- 按“隔离两条 CAS 链路”的原则,e-card 小组件更新延后到教务刷新收尾之后
- 更新当前账号密码时显式 `login()` 重建会话(refresh 仅在无会话时才内部重登,
  旧 spider 缓存着旧密码)

## 行为变化

- 登录弹窗在登录成功后立即关闭,数据后台流式刷入(与启动、切换体验一致),
  不再等全量抓取完成
- “退出登录”语义变为“删除该账号的本机档案”,此前退出会保留自建任务
- 新添账号的首个后台刷新周期会收到一次“首次成绩推送”引导通知(每账号独立,预期内)

## 已知取舍

- 切出账号的在途刷新结果丢弃,下次激活时重新刷新
- scholarBox 体积随账号数线性增长(每账号一份 JSON 快照)

## 验证

- `flutter analyze` 无新增告警,`dart format` 通过
- 使用自己和室友的账号手动测试，未发现异常。

## 其他

- .gitignore 追加忽略 Claude 相关本地文件(`.claude/`、`CLAUDE.md`)